### PR TITLE
Fix coverage reporting on Windows

### DIFF
--- a/CMakeUnitRunner.cmake
+++ b/CMakeUnitRunner.cmake
@@ -290,6 +290,8 @@ function (_append_configure_step TEST_NAME
         set (TEST_DIRECTORY_CONFIGURE_SCRIPT
              "${TEST_DIRECTORY_NAME}/CMakeLists.txt")
         set (TEST_DIRECTORY_CONFIGURE_SCRIPT_CONTENTS
+             "project (TestProject CXX C)\n"
+             "cmake_minimum_required (VERSION 2.8 FATAL_ERROR)\n"
              "if (POLICY CMP0025)\n"
              "  cmake_policy (SET CMP0025 NEW)\n"
              "endif (POLICY CMP0025)\n"


### PR DESCRIPTION
Warnings were getting caught up in the coverage script on Windows. This was causing the coverage script to fail due to extraneous lines being present.

Also fixed a small typo which caused the coverage trace lines to be truncated at drive letters on Windows.

Finally, updated appveyor.yml and .travis.yml to ensure that these parts are tested.

Cache the CMake installer download on AppVeyor.
