### PR TITLE
Force verbosity at the build step level.

### DIFF
--- a/CMakeUnitRunner.cmake
+++ b/CMakeUnitRunner.cmake
@@ -547,10 +547,18 @@ function (_append_build_step PARENT_DRIVER_SCRIPT_CONTENTS
 
     endif ("${TARGET}" STREQUAL "all")
 
+    if ("${CMAKE_MAKE_PROGRAM}" MATCHES ".*ninja.*")
+
+        set (BUILD_TOOL_VERBOSE_OPTION "-v")
+
+    endif ("${CMAKE_MAKE_PROGRAM}" MATCHES ".*ninja.*")
+
     set (BUILD_COMMAND "${CMAKE_COMMAND}"
                        --build
                        "${TEST_WORKING_DIRECTORY_NAME}"
-                       ${TARGET_OPTION})
+                       ${TARGET_OPTION}
+                       --
+                       "${BUILD_TOOL_VERBOSE_OPTION}")
     set (DRIVER_SCRIPT_CONTENTS ${${PARENT_DRIVER_SCRIPT_CONTENTS}})
     _add_driver_step (DRIVER_SCRIPT_CONTENTS BUILD
                       COMMAND ${BUILD_COMMAND}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -115,6 +115,9 @@ add_cmake_build_test (CMakeBuildTestWarningsNotErrorsWhereWErrorDisabled
 add_cmake_build_test (CMakeTestFilesRecordedInTracefileAcrossTests
                       CMakeTestFilesRecordedInTracefileAcrossTestsVerify)
 
+add_cmake_build_test (CMakeTestsHaveVerboseOutput
+                      CMakeTestsHaveVerboseOutputVerify)
+
 # Tests for CMakeTraceToLCov
 add_cmake_test (LinesStartingWithCommentNotExecutable)
 add_cmake_test (LinesWithNoContentNotExecutable)

--- a/tests/CMakeTestsHaveVerboseOutput.cmake
+++ b/tests/CMakeTestsHaveVerboseOutput.cmake
@@ -1,0 +1,32 @@
+# /tests/CMakeTestsHaveVerboseOutput.cmake
+#
+# Adds a test which adds a custom target with a command
+# to the ALL target.
+#
+# See LICENCE.md for Copyright information
+
+include (CMakeUnit)
+include (CMakeUnitRunner)
+
+set (TEST_NAME "SampleTest")
+set (TEST_NAME_VERIFY "SampleTestVerify")
+set (TEST_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${TEST_NAME}.cmake")
+set (TEST_VERIFY_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${TEST_NAME_VERIFY}.cmake")
+
+set (SOURCE_FILE "${CMAKE_CURRENT_BINARY_DIR}/Source.cpp")
+set (GENERATED_FILE "${CMAKE_CURRENT_BINARY_DIR}/Generated.cpp")
+
+file (WRITE "${SOURCE_FILE}" "")
+file (WRITE "${TEST_FILE}"
+      "include (CMakeUnit)\n"
+      "add_custom_command (OUTPUT\n"
+      "                    \"${GENERATED_FILE}\"\n"
+      "                    COMMAND\n"
+      "                    \"${CMAKE_COMMAND}\" -E touch\n"
+      "                    \"${GENERATED_FILE}\")\n"
+      "add_custom_target (custom_target ALL\n"
+      "                   SOURCES \"${GENERATED_FILE}\")\n")
+file (WRITE "${TEST_VERIFY_FILE}" "")
+
+bootstrap_cmake_unit (VARIABLES CMAKE_MODULE_PATH)
+add_cmake_build_test (${TEST_NAME} ${TEST_NAME_VERIFY})

--- a/tests/CMakeTestsHaveVerboseOutputVerify.cmake
+++ b/tests/CMakeTestsHaveVerboseOutputVerify.cmake
@@ -1,0 +1,18 @@
+# /tests/CMakeTestsHaveVerboseOutputVerify.cmake
+#
+# Checks that cmake -E touch Generated.cpp was in the test output -
+# if it was, it means that this command was run with verbose
+# output.
+#
+# See LICENCE.md for Copyright information
+
+include (CMakeUnit)
+
+cmake_unit_escape_string ("${CMAKE_COMMAND}" ESCAPED_CMAKE_COMMAND)
+
+set (TEST_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/TEST.output")
+
+set (CUSTOM_COMMAND_CMAKE_REGEX
+     "^.*${ESCAPED_CMAKE_COMMAND} -E touch .*Generated.cpp.*$")
+assert_file_has_line_matching ("${TEST_OUTPUT}"
+                               "${CUSTOM_COMMAND_CMAKE_REGEX}")


### PR DESCRIPTION
Some generators don't respect CMAKE_VERBOSE_MAKEFILE, so pass the verbosity
option to those generators directly
