### PR TITLE
Improve test verbose output.

### DIFF
--- a/CMakeTraceToLCov.cmake
+++ b/CMakeTraceToLCov.cmake
@@ -28,8 +28,7 @@ if (NOT LCOV_OUTPUT)
 
 endif (NOT LCOV_OUTPUT)
 
-file (READ "${TRACEFILE}" TRACEFILE_CONTENTS)
-string (REPLACE "\n" ";" TRACEFILE_CONTENTS "${TRACEFILE_CONTENTS}")
+file (STRINGS "${TRACEFILE}" TRACEFILE_CONTENTS)
 
 # Open the file and read it for "executable lines"
 # An executable line is any line that is not all whitespace or does not
@@ -48,6 +47,8 @@ function (determine_executable_lines FILE)
     list (APPEND _ALL_COVERAGE_FILES "${FILE}")
     set (_ALL_COVERAGE_FILES "${_ALL_COVERAGE_FILES}" PARENT_SCOPE)
 
+    # file (STRINGS) can't be used here as a skips empty lines. We need
+    # line-for-line accuracy.
     file (READ "${FILE}" FILE_CONTENTS)
 
     # Can't have semicolons, doesn't matter what they are, just change them

--- a/util/InjectProblematicRegexIntoDriverHack.cmake
+++ b/util/InjectProblematicRegexIntoDriverHack.cmake
@@ -1,0 +1,28 @@
+# /util/InjectProblematicRejectIntoDriverHack.cmake
+#
+# Reads a driver script as indicated by DRIVER_SCRIPT and replaces
+# all instances of @PROBLEMATIC_REGEX_ONE@ and @PROBLEMATIC_REGEX_TWO@ with
+# \\\\\\\\] and \\\\\\\\[ respectively.
+#
+# For some inexplicable reason, this regex (which appears in
+# CMakeCheckCompilerId) causes ";" based list separation to break
+# completely. It cannot appear in any file where we need to read
+# the contents of that file in order to appear in a coverage report
+# (which is also why this file should NOT be listed as a coverage
+#  candidate).
+#
+# This string can be injected into our "driver" scripts which can
+# then be used as a mechanism to replace instances of the problematic
+# regex with nothing.
+#
+# See LICENCE.md for Copyright information
+
+set (DRIVER_SCRIPT_FILE "" CACHE STRING "")
+file (READ "${DRIVER_SCRIPT_FILE}" DRIVER_SCRIPT_CONTENTS)
+string (REPLACE "@PROBLEMATIC_REGEX_ONE@" "]"
+        DRIVER_SCRIPT_CONTENTS
+        "${DRIVER_SCRIPT_CONTENTS}")
+string (REPLACE "@PROBLEMATIC_REGEX_TWO@" "["
+        DRIVER_SCRIPT_CONTENTS
+        "${DRIVER_SCRIPT_CONTENTS}")
+file (WRITE "${DRIVER_SCRIPT_FILE}" "${DRIVER_SCRIPT_CONTENTS}")


### PR DESCRIPTION
Each line of the output string is now tagged with its
corresponding step and whether or not it is OUTPUT or ERROR.

In addition, coverage tracefile lines are now filtered out of
the configure error output. Just warnings and errors are shown.
