### PR TITLE
Add convenience functions to generate source files and simple binaries

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,7 @@ add_cmake_test (InitialCacheWrittenAfterTestAdded)
 add_cmake_test (InitialCacheContainsForwardedVariables)
 add_cmake_test (DriverScriptWrittenAfterTestAdded)
 
+# Test adding CMake test and error behaviour
 add_cmake_build_test (CMakeTestAddedWhereSetupScriptExists
                       CMakeTestAddedWhereSetupScriptExistsVerify)
 add_cmake_build_test (CMakeTestNotAddedWhenSetupScriptDoesntExist
@@ -94,11 +95,13 @@ add_cmake_build_test (CMakeBuildTestErrorOnVerifyFail
                       CMakeBuildTestErrorOnVerifyFailVerify
                       ALLOW_TEST_FAIL)
 
+# Test that certain steps are not run where ALLOW_FAIL is specified
 add_cmake_build_test (CMakeBuildTestBuildStepNotRunIfConfigureCanFail
                       CMakeBuildTestBuildStepNotRunIfConfigureCanFailVerify)
 add_cmake_build_test (CMakeBuildTestTestStepNotRunIfBuildCanFail
                       CMakeBuildTestTestStepNotRunIfBuildCanFailVerify)
 
+# Custom target, clean step
 add_cmake_build_test (CMakeBuildTestWithCustomTarget
                       CMakeBuildTestWithCustomTargetVerify)
 add_cmake_build_test (CMakeBuildTestCleanStepAlwaysRuns
@@ -106,17 +109,44 @@ add_cmake_build_test (CMakeBuildTestCleanStepAlwaysRuns
 add_cmake_build_test (CMakeBuildTestCleanStepNotRunOnNoClean
                       CMakeBuildTestCleanStepNotRunOnNoCleanVerify)
 
+# Convert warnings to errors
 add_cmake_build_test (CMakeBuildTestWarningsAreErrors
                       CMakeBuildTestWarningsAreErrorsVerify
                       ALLOW_TEST_FAIL)
 add_cmake_build_test (CMakeBuildTestWarningsNotErrorsWhereWErrorDisabled
                       CMakeBuildTestWarningsNotErrorsWhereWErrorDisabledVerify)
 
+# Tracefile recording
 add_cmake_build_test (CMakeTestFilesRecordedInTracefileAcrossTests
                       CMakeTestFilesRecordedInTracefileAcrossTestsVerify)
 
+# Verbose output
 add_cmake_build_test (CMakeTestsHaveVerboseOutput
                       CMakeTestsHaveVerboseOutputVerify)
+
+# Source file and executable generation
+add_cmake_test (SourceFileCreatedBeforeBuildExists)
+add_cmake_test (SourceFileCreatedBeforeBuildWithCustomName)
+add_cmake_test (SourceFileCreatedBeforeBuildWithDefines)
+add_cmake_test (SourceFileCreatedBeforeBuildWithIncludes)
+add_cmake_test (SourceFileCreatedBeforeBuildWithIncludesInsideIncludeDir)
+add_cmake_test (SourceFileCreatedBeforeBuildHasPrependedContents)
+add_cmake_test (SourceFileCreatedBeforeBuildWithFunctionDecls)
+add_cmake_test (SourceFileCreatedBeforeBuildWithFunctionDefinitions)
+add_cmake_test (SourceFileCreatedBeforeBuildNoFunctionDefinitionsIfHeader)
+add_cmake_test (SourceFileCreatedBeforeBuildHeaderGuardsIfHeader)
+
+# Generated source files
+add_cmake_build_test (SourceFileGeneratedDuringBuildExists
+                      SourceFileGeneratedDuringBuildExistsVerify)
+add_cmake_build_test (GeneratedAndCreatedSourceFilesEqual
+                      GeneratedAndCreatedSourceFilesEqualVerify)
+
+# Superficial Executables and Libraries
+add_cmake_build_test (CreateSimpleExecutable
+                      CreateSimpleExecutableVerify)
+add_cmake_build_test (CreateSimpleLibrary
+                      CreateSimpleLibraryVerify)
 
 # Tests for CMakeTraceToLCov
 add_cmake_test (LinesStartingWithCommentNotExecutable)

--- a/tests/CreateSimpleExecutable.cmake
+++ b/tests/CreateSimpleExecutable.cmake
@@ -1,0 +1,11 @@
+# /tests/CreateSimpleExecutable.cmake
+#
+# Creates a simple executable named "executable" by using
+# cmake_unit_create_simple_executable
+#
+# See LICENCE.md for Copyright information.
+
+include (CMakeUnit)
+
+cmake_unit_create_simple_executable (executable)
+export (TARGETS executable FILE ${CMAKE_CURRENT_BINARY_DIR}/exports.cmake)

--- a/tests/CreateSimpleExecutableVerify.cmake
+++ b/tests/CreateSimpleExecutableVerify.cmake
@@ -1,0 +1,17 @@
+# /tests/CreateSimpleExecutableVerify.cmake
+#
+# Looks up the location of the "executable" target by using
+# cmake_unit_get_target_location_from_exports from the
+# ${CMAKE_CURRENT_BINARY_DIR}/exports.cmake and executes it
+#
+# See LICENCE.md for Copyright information.
+
+include (CMakeUnit)
+
+set (EXPORTS_FILE "${CMAKE_CURRENT_BINARY_DIR}/exports.cmake")
+cmake_unit_get_target_location_from_exports ("${EXPORTS_FILE}"
+                                             executable
+                                             LOCATION)
+
+assert_file_exists ("${LOCATION}")
+assert_command_executes_with_success (COMMAND "${LOCATION}")

--- a/tests/CreateSimpleLibrary.cmake
+++ b/tests/CreateSimpleLibrary.cmake
@@ -1,0 +1,13 @@
+# /tests/CreateSimpleLibrary.cmake
+#
+# Creates a simple executable named "executable" by using
+# cmake_unit_create_simple_executable and links to a simple library
+# named "library" created by using cmake_unit_create_simple_library
+#
+# See LICENCE.md for Copyright information.
+
+include (CMakeUnit)
+
+cmake_unit_create_simple_library (library SHARED FUNCTIONS function)
+cmake_unit_create_simple_executable (executable)
+target_link_libraries (executable library)

--- a/tests/CreateSimpleLibraryVerify.cmake
+++ b/tests/CreateSimpleLibraryVerify.cmake
@@ -1,0 +1,16 @@
+# /tests/CreateSimpleLibraryVerify.cmake
+#
+# Checks the build output to make sure a "simple" executable is linked to
+# the "simple" library.
+#
+# See LICENCE.md for Copyright information.
+
+include (CMakeUnit)
+
+set (BUILD_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/BUILD.output")
+
+# There's not too much particularly useful to verify here, other than
+# the executable and the library being mentioned because the order
+# in which they are mentioned is generator specific
+assert_file_has_line_matching ("${BUILD_OUTPUT}" "^.*library.*$")
+assert_file_has_line_matching ("${BUILD_OUTPUT}" "^.*executable.*$")

--- a/tests/GeneratedAndCreatedSourceFilesEqual.cmake
+++ b/tests/GeneratedAndCreatedSourceFilesEqual.cmake
@@ -1,0 +1,19 @@
+# /tests/GeneratedAndCreatedSourceFilesEqual.cmake
+#
+# Check that source files created and generated with the same options
+# are completely equal
+#
+# See LICENCE.md for Copyright information.
+
+include (CMakeUnit)
+
+set (GENERATE_OPTIONS
+     NAME "CustomSource.cpp"
+     INCLUDES "custom_include.h" "other_include.h"
+     DEFINES "CUSTOM_DEFINITION" "OTHER_DEFINITION"
+     FUNCTIONS "function_one" "function_two"
+     PREPEND_CONTENTS "static int integer_variable@SEMICOLON@")
+
+cmake_unit_generate_source_file_during_build (GENERATED_DURING_TARGET
+                                              ${GENERATE_OPTIONS})
+cmake_unit_create_source_file_before_build (${GENERATE_OPTIONS})

--- a/tests/GeneratedAndCreatedSourceFilesEqualVerify.cmake
+++ b/tests/GeneratedAndCreatedSourceFilesEqualVerify.cmake
@@ -1,0 +1,14 @@
+# /tests/GeneratedAndCreatedSourceFilesEqualVerify.cmake
+#
+# Checks after build that our source file was generated and exists and is
+# completely equal (eg, hash is equal) to a file created during configure
+# time.
+#
+# See LICENCE.md for Copyright information.
+
+include (CMakeUnit)
+
+file (SHA512 "${CMAKE_CURRENT_SOURCE_DIR}/CustomSource.cpp" CREATED_HASH)
+file (SHA512 "${CMAKE_CURRENT_BINARY_DIR}/CustomSource.cpp" GENERATED_HASH)
+
+assert_variable_is (CREATED_HASH STRING EQUAL "${GENERATED_HASH}")

--- a/tests/SourceFileCreatedBeforeBuildExists.cmake
+++ b/tests/SourceFileCreatedBeforeBuildExists.cmake
@@ -1,0 +1,13 @@
+# /tests/SourceFileCreatedBeforeBuildExists.cmake
+#
+# Check that a source file by the name Source.cpp was created in
+# ${CMAKE_CURRENT_SOURCE_DIR} when we call
+# cmake_unit_create_source_file_before_build
+#
+# See LICENCE.md for Copyright information.
+
+include (CMakeUnit)
+
+cmake_unit_create_source_file_before_build ()
+
+assert_file_exists ("${CMAKE_CURRENT_SOURCE_DIR}/Source.cpp")

--- a/tests/SourceFileCreatedBeforeBuildHasPrependedContents.cmake
+++ b/tests/SourceFileCreatedBeforeBuildHasPrependedContents.cmake
@@ -1,0 +1,16 @@
+# /tests/SourceFileCreatedBeforeBuildHasPrependedContents.cmake
+#
+# Check that a source file by the name Source.cpp was created in
+# ${CMAKE_CURRENT_SOURCE_DIR} with specified prepended contents
+# (after defines and includes)
+#
+# See LICENCE.md for Copyright information.
+
+include (CMakeUnit)
+
+set (PREPEND_CONTENTS_INPUT "static int i@SEMICOLON@")
+cmake_unit_create_source_file_before_build (PREPEND_CONTENTS
+                                            "${PREPEND_CONTENTS_INPUT}")
+
+assert_file_has_line_matching ("${CMAKE_CURRENT_SOURCE_DIR}/Source.cpp"
+                               "^static int i.$")

--- a/tests/SourceFileCreatedBeforeBuildHeaderGuardsIfHeader.cmake
+++ b/tests/SourceFileCreatedBeforeBuildHeaderGuardsIfHeader.cmake
@@ -1,0 +1,23 @@
+# /tests/SourceFileCreatedBeforeBuildHeaderGuardsIfHeader.cmake
+#
+# Check that a source file by the name Header.h was created in
+# ${CMAKE_CURRENT_SOURCE_DIR} and contains header guards like
+# #ifdef HEADER_H
+# #define HEADER_H
+# ...
+# #endif
+#
+# See LICENCE.md for Copyright information.
+
+include (CMakeUnit)
+
+cmake_unit_create_source_file_before_build (NAME "Header.h"
+                                            PREPEND_CONTENTS
+                                            "int foo@SEMICOLON@")
+
+assert_file_has_line_matching ("${CMAKE_CURRENT_SOURCE_DIR}/Header.h"
+                               "^.*ifndef HEADER_H")
+assert_file_has_line_matching ("${CMAKE_CURRENT_SOURCE_DIR}/Header.h"
+                               "^.*define HEADER_H")
+assert_file_has_line_matching ("${CMAKE_CURRENT_SOURCE_DIR}/Header.h"
+                               "^.*endif")

--- a/tests/SourceFileCreatedBeforeBuildNoFunctionDefinitionsIfHeader.cmake
+++ b/tests/SourceFileCreatedBeforeBuildNoFunctionDefinitionsIfHeader.cmake
@@ -1,0 +1,16 @@
+# /tests/SourceFileCreatedBeforeBuildNoFunctionDefinitionsIfHeader.cmake
+#
+# Check that a source file by the name Header.h was created in
+# ${CMAKE_CURRENT_SOURCE_DIR} but does not contain a definition like
+# int custom_function ()\n{\n    return 1;\n} when we call
+# cmake_unit_create_source_file_before_build with FUNCTIONS custom_function
+#
+# See LICENCE.md for Copyright information.
+
+include (CMakeUnit)
+
+cmake_unit_create_source_file_before_build (NAME "Header.h"
+                                            FUNCTIONS custom_function)
+
+assert_file_does_not_have_line_matching ("${CMAKE_CURRENT_SOURCE_DIR}/Header.h"
+                                         "^.*return 1.*$")

--- a/tests/SourceFileCreatedBeforeBuildWithCustomName.cmake
+++ b/tests/SourceFileCreatedBeforeBuildWithCustomName.cmake
@@ -1,0 +1,13 @@
+# /tests/SourceFileCreatedBeforeBuildWithCustomName.cmake
+#
+# Check that a source file by the name CustomName.cpp was created in
+# ${CMAKE_CURRENT_SOURCE_DIR} when we call
+# cmake_unit_create_source_file_before_build with NAME
+#
+# See LICENCE.md for Copyright information.
+
+include (CMakeUnit)
+
+cmake_unit_create_source_file_before_build (NAME "CustomName.cpp")
+
+assert_file_exists ("${CMAKE_CURRENT_SOURCE_DIR}/CustomName.cpp")

--- a/tests/SourceFileCreatedBeforeBuildWithDefines.cmake
+++ b/tests/SourceFileCreatedBeforeBuildWithDefines.cmake
@@ -1,0 +1,14 @@
+# /tests/SourceFileCreatedBeforeBuildWithDefines.cmake
+#
+# Check that a source file by the name Source.cpp was created in
+# ${CMAKE_CURRENT_SOURCE_DIR} with #define CUSTOM_DEFINE when we call
+# cmake_unit_create_source_file_before_build with DEFINES CUSTOM_DEFINE
+#
+# See LICENCE.md for Copyright information.
+
+include (CMakeUnit)
+
+cmake_unit_create_source_file_before_build (DEFINES "CUSTOM_DEFINE")
+
+assert_file_has_line_matching ("${CMAKE_CURRENT_SOURCE_DIR}/Source.cpp"
+                               "^.define CUSTOM_DEFINE$")

--- a/tests/SourceFileCreatedBeforeBuildWithFunctionDecls.cmake
+++ b/tests/SourceFileCreatedBeforeBuildWithFunctionDecls.cmake
@@ -1,0 +1,15 @@
+# /tests/SourceFileCreatedBeforeBuildWithFunctionDecls.cmake
+#
+# Check that a source file by the name Source.cpp was created in
+# ${CMAKE_CURRENT_SOURCE_DIR} with a declaration like
+# int custom_function (); when we call
+# cmake_unit_create_source_file_before_build with FUNCTIONS custom_function
+#
+# See LICENCE.md for Copyright information.
+
+include (CMakeUnit)
+
+cmake_unit_create_source_file_before_build (FUNCTIONS custom_function)
+
+assert_file_has_line_matching ("${CMAKE_CURRENT_SOURCE_DIR}/Source.cpp"
+                               "^int custom_function ...$")

--- a/tests/SourceFileCreatedBeforeBuildWithFunctionDefinitions.cmake
+++ b/tests/SourceFileCreatedBeforeBuildWithFunctionDefinitions.cmake
@@ -1,0 +1,15 @@
+# /tests/SourceFileCreatedBeforeBuildWithFunctionDefinitions.cmake
+#
+# Check that a source file by the name Source.cpp was created in
+# ${CMAKE_CURRENT_SOURCE_DIR} with a definition like
+# int custom_function ()\n{\n    return 1;\n} when we call
+# cmake_unit_create_source_file_before_build with FUNCTIONS custom_function
+#
+# See LICENCE.md for Copyright information.
+
+include (CMakeUnit)
+
+cmake_unit_create_source_file_before_build (FUNCTIONS custom_function)
+
+assert_file_has_line_matching ("${CMAKE_CURRENT_SOURCE_DIR}/Source.cpp"
+                               "^.*return 0.*$")

--- a/tests/SourceFileCreatedBeforeBuildWithIncludes.cmake
+++ b/tests/SourceFileCreatedBeforeBuildWithIncludes.cmake
@@ -1,0 +1,14 @@
+# /tests/SourceFileCreatedBeforeBuildWithIncludes.cmake
+#
+# Check that a source file by the name Source.cpp was created in
+# ${CMAKE_CURRENT_SOURCE_DIR} with #include "my_include.h" when we call
+# cmake_unit_create_source_file_before_build with INCLUDES my_include.h
+#
+# See LICENCE.md for Copyright information.
+
+include (CMakeUnit)
+
+cmake_unit_create_source_file_before_build (INCLUDES my_include.h)
+
+assert_file_has_line_matching ("${CMAKE_CURRENT_SOURCE_DIR}/Source.cpp"
+                               "^.include \"my_include.h\"$")

--- a/tests/SourceFileCreatedBeforeBuildWithIncludesInsideIncludeDir.cmake
+++ b/tests/SourceFileCreatedBeforeBuildWithIncludesInsideIncludeDir.cmake
@@ -1,0 +1,21 @@
+# /tests/SourceFileCreatedBeforeBuildWithIncludesInsideIncludeDir.cmake
+#
+# Check that a source file by the name Source.cpp was created in
+# ${CMAKE_CURRENT_SOURCE_DIR} with #include <include/my_include.h> when we call
+# cmake_unit_create_source_file_before_build with
+# INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/include/my_include.h
+# and INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}
+#
+# See LICENCE.md for Copyright information.
+
+include (CMakeUnit)
+
+set (INCLUDE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+set (MY_INCLUDE "${INCLUDE_DIRECTORY}/include/my_include.h")
+cmake_unit_create_source_file_before_build (INCLUDES
+                                            "${MY_INCLUDE}"
+                                            INCLUDE_DIRECTORIES
+                                            "${INCLUDE_DIRECTORY}")
+
+assert_file_has_line_matching ("${CMAKE_CURRENT_SOURCE_DIR}/Source.cpp"
+                               "^.include <include/my_include.h>$")

--- a/tests/SourceFileGeneratedDuringBuildExists.cmake
+++ b/tests/SourceFileGeneratedDuringBuildExists.cmake
@@ -1,0 +1,14 @@
+# /tests/SourceFileGeneratedDuringBuildExists.cmake
+#
+# Check that a source file by the name Source.cpp was created in
+# ${CMAKE_CURRENT_SOURCE_DIR} when we call
+# cmake_unit_create_source_file_before_build
+#
+# See LICENCE.md for Copyright information.
+
+include (CMakeUnit)
+
+cmake_unit_generate_source_file_during_build (GENERATED_DURING_TARGET)
+
+# File should not exist yet
+assert_file_does_not_exist ("${CMAKE_CURRENT_SOURCE_DIR}/Source.cpp")

--- a/tests/SourceFileGeneratedDuringBuildExistsVerify.cmake
+++ b/tests/SourceFileGeneratedDuringBuildExistsVerify.cmake
@@ -1,0 +1,9 @@
+# /tests/SourceFileGeneratedDuringBuildVerify.cmake
+#
+# Checks after build that our source file was generated and exists
+#
+# See LICENCE.md for Copyright information.
+
+include (CMakeUnit)
+
+assert_file_exists ("${CMAKE_CURRENT_BINARY_DIR}/Source.cpp")


### PR DESCRIPTION
Use cmake_unit_create_source_file_before_build to generate a source
file during the configure phase. A NAME for the source file can be
passed in as well as a list of INCLUDES, DEFINES and FUNCTIONS. Custom
contents can be added using PREPEND_CONTENTS.

Use cmake_unit_generate_source_file_during_build to generate a source
file in the build phase. This function takes similar arguments to
cmake_unit_create_source_file_before_build.

Use cmake_unit_create_simple_executable to create a simple executable
with the name NAME that just returns 0.

Use cmake_unit_create_simple_library with the name NAME and some
specified FUNCTIONS to create a simple library that has those
functions. The functions will be exported automatically.

If you need to get the full path to a compiled library or executable
in the verify phase, then use export (TARGETS ${TARGET}) in the
configure phase and then use
cmake_unit_get_target_location_from_exports specifying the location
of the EXPORTS file in the build-directory and the name of the target
to look up.
