### PR TITLE
Depart from the convention of repeating conditions, function names etc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   # 1. Spaces between control and condition (preferred style)
   # 2. Indentation errors
   # 3. Logic inside else/endif (preferred style)
-  - find . -type f -name "*.cmake" -not -path "./tests/build/*"| xargs cmakelint --spaces=4 --filter=-whitespace/extra,-readability/logic,-whitespace/indent > .cmake-lint-log
+  - find . -type f -name "*.cmake" -not -path "./tests/build/*"| xargs cmakelint --spaces=4 --filter=-whitespace/extra,-whitespace/indent > .cmake-lint-log
   - cat .cmake-lint-log
   # Fails if file has length
   - echo "! [ -s .cmake-lint-log ]" > .check-link-script.bash

--- a/CMakeTraceToLCov.cmake
+++ b/CMakeTraceToLCov.cmake
@@ -20,13 +20,13 @@ if (NOT TRACEFILE)
 
     message (FATAL_ERROR "TRACEFILE must be specified")
 
-endif (NOT TRACEFILE)
+endif ()
 
 if (NOT LCOV_OUTPUT)
 
     message (FATAL_ERROR "LCOV_OUTPUT must be specified")
 
-endif (NOT LCOV_OUTPUT)
+endif ()
 
 file (STRINGS "${TRACEFILE}" TRACEFILE_CONTENTS)
 
@@ -42,7 +42,7 @@ function (determine_executable_lines FILE)
 
         return ()
 
-    endif (NOT FILE_INDEX EQUAL -1)
+    endif ()
 
     list (APPEND _ALL_COVERAGE_FILES "${FILE}")
     set (_ALL_COVERAGE_FILES "${_ALL_COVERAGE_FILES}" PARENT_SCOPE)
@@ -90,7 +90,7 @@ function (determine_executable_lines FILE)
 
                 set (DISQUALIFIED_BECAUSE_LINE_ONLY_WHITESPACE TRUE)
 
-            endif (NOT STRIPPED_LINE)
+            endif ()
 
             # The following patterns are always non-executable
             set (NON_EXECUTABLE_LINE_MATCHES
@@ -107,7 +107,7 @@ function (determine_executable_lines FILE)
                     set (DISQUALIFIED_DUE_TO_MATCH TRUE)
                     break ()
 
-                endif ("${LINE}" MATCHES "${MATCH}")
+                endif ()
 
             endforeach ()
 
@@ -119,11 +119,11 @@ function (determine_executable_lines FILE)
                 string (SUBSTRING "${LINE}" 0 ${COMMENT_INDEX}
                         LINE_WITHOUT_COMMENTS)
 
-            else (NOT COMMENT_INDEX EQUAL -1)
+            else ()
 
                 set (LINE_WITHOUT_COMMENTS "${LINE}")
 
-            endif (NOT COMMENT_INDEX EQUAL -1)
+            endif ()
 
             string (STRIP "${LINE_WITHOUT_COMMENTS}"
                     LINE_STRIPPED_WITH_NO_COMMENTS)
@@ -143,7 +143,7 @@ function (determine_executable_lines FILE)
                 math (EXPR LAST_CLOSE_BRACKET_INDEX
                       "${LAST_CLOSE_BRACKET_INDEX} + 1")
 
-            endif (NOT LAST_CLOSE_BRACKET_INDEX EQUAL -1)
+            endif ()
 
             if (IN_OPENED_BRACKET_REGION OR
                 NOT OPEN_BRACKET_INDEX EQUAL -1)
@@ -152,11 +152,11 @@ function (determine_executable_lines FILE)
 
                     set (IN_OPENED_BRACKET_REGION FALSE)
 
-                else (LAST_CLOSE_BRACKET_INDEX EQUAL LINE_LENGTH)
+                else ()
 
                     set (IN_OPENED_BRACKET_REGION TRUE)
 
-                endif (LAST_CLOSE_BRACKET_INDEX EQUAL LINE_LENGTH)
+                endif ()
 
             endif (IN_OPENED_BRACKET_REGION OR
                    NOT OPEN_BRACKET_INDEX EQUAL -1)
@@ -175,7 +175,7 @@ function (determine_executable_lines FILE)
 
             math (EXPR NEXT_LINE_INDEX "${NEXT_LINE_INDEX} + 1")
 
-        endif (NOT NEXT_LINE_INDEX EQUAL -1)
+        endif ()
 
         math (EXPR LINE_COUNTER "${LINE_COUNTER} + 1")
 
@@ -203,7 +203,7 @@ foreach (LINE ${TRACEFILE_CONTENTS})
         string (SUBSTRING "${LINE}" ${HEADER_LENGTH} -1 FILEPATH)
         determine_executable_lines ("${FILEPATH}")
 
-    endif ("${LINE}" MATCHES "FILE.*$")
+    endif ()
 
     if (NOT "${LINE}" MATCHES "TEST.*$" AND
         NOT "${LINE}" MATCHES "FILE.*$")
@@ -227,7 +227,7 @@ foreach (LINE ${TRACEFILE_CONTENTS})
 
             set ("${HIT_VARIABLE}" 0)
 
-        endif (NOT "${${HIT_VARIABLE}}")
+        endif ()
 
         math (EXPR "${HIT_VARIABLE}" "${${HIT_VARIABLE}} + 1")
 
@@ -253,7 +253,7 @@ foreach (FILE ${_ALL_COVERAGE_FILES})
                              " to ${CMAKE_CURRENT_SOURCE_DIR}. Are you running "
                              " this script from the toplevel source directory?")
 
-    endif (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${RELATIVE_PATH_TO_FILE}")
+    endif ()
 
     list (APPEND LCOV_OUTPUT_CONTENTS
           "SF:${RELATIVE_PATH_TO_FILE}\n")
@@ -272,14 +272,14 @@ foreach (FILE ${_ALL_COVERAGE_FILES})
             list (APPEND SOURCE_FILE_HITS
                   "DA:${EXECUTABLE_LINE},0")
 
-        else (NOT "${${HIT_VARIABLE}}")
+        else ()
 
             list (APPEND SOURCE_FILE_HITS
                   "DA:${EXECUTABLE_LINE},${${HIT_VARIABLE}}")
             math (EXPR NUMBER_OF_LINES_WITH_POSITIVE_HIT_COUNTS
                   "${NUMBER_OF_LINES_WITH_POSITIVE_HIT_COUNTS} + 1")
 
-        endif (NOT "${${HIT_VARIABLE}}")
+        endif ()
 
     endforeach ()
 

--- a/CMakeUnit.cmake
+++ b/CMakeUnit.cmake
@@ -31,7 +31,7 @@ if (_CMAKE_UNIT_INCLUDED)
 
     return ()
 
-endif (_CMAKE_UNIT_INCLUDED)
+endif ()
 set (_CMAKE_UNIT_INCLUDED TRUE)
 
 include (CMakeParseArguments)
@@ -60,7 +60,7 @@ function (cmake_unit_escape_string INPUT OUTPUT_VARIABLE)
 
     set (${OUTPUT_VARIABLE} "${INPUT}" PARENT_SCOPE)
 
-endfunction (cmake_unit_escape_string)
+endfunction ()
 
 function (_cmake_unit_make_dummy_print_message_target TARGET_RETURN)
 
@@ -81,7 +81,7 @@ function (_cmake_unit_make_dummy_print_message_target TARGET_RETURN)
 
     set (${TARGET_RETURN} ${TARGET_NAME} PARENT_SCOPE)
 
-endfunction (_cmake_unit_make_dummy_print_message_target)
+endfunction ()
 
 # Wraps add_custom_command to print out the COMMAND line on generators that
 # wont print that even when verbose mode is enabled.
@@ -109,11 +109,11 @@ function (add_custom_command)
         list (APPEND CMAKE_UNIT_ACC_DEPENDS
               ${TARGET})
 
-    endif (ACC_COMMAND)
+    endif ()
 
     _add_custom_command (${ARGN} DEPENDS ${CMAKE_UNIT_ACC_DEPENDS})
 
-endfunction (add_custom_command)
+endfunction ()
 
 set (_CMAKE_UNIT_SOURCE_FILE_OPTION_ARGS)
 set (_CMAKE_UNIT_SOURCE_FILE_SINGLEVAR_ARGS NAME FUNCTIONS_EXPORT_TARGET)
@@ -144,7 +144,7 @@ function (_cmake_unit_get_created_source_file_contents CONTENTS_RETURN
 
         set (GET_CREATED_NAME "Source.cpp")
 
-    endif (NOT GET_CREATED_NAME)
+    endif ()
 
     # Detect intended file type from filename
 
@@ -159,11 +159,11 @@ function (_cmake_unit_get_created_source_file_contents CONTENTS_RETURN
 
         set (SOURCE_TYPE HEADER)
 
-    else (SOURCE_INDEX EQUAL -1)
+    else ()
 
         set (SOURCE_TYPE SOURCE)
 
-    endif (SOURCE_INDEX EQUAL -1)
+    endif ()
 
     # Header guards (if header)
     if ("${SOURCE_TYPE}" STREQUAL "HEADER")
@@ -175,7 +175,7 @@ function (_cmake_unit_get_created_source_file_contents CONTENTS_RETURN
               "#ifndef ${HEADER_GUARD}"
               "#define ${HEADER_GUARD}")
 
-    endif ("${SOURCE_TYPE}" STREQUAL "HEADER")
+    endif ()
 
     # If this is a "source" file and FUNCTIONS_EXPORT_TARGET is set then
     # we're building a library. As such, we need to insert some platform
@@ -190,7 +190,7 @@ function (_cmake_unit_get_created_source_file_contents CONTENTS_RETURN
                 EXPORT_TARGET_UPPER)
         set (EXPORT_MACRO "${EXPORT_TARGET_UPPER}_EXPORT ")
 
-    endif (GET_CREATED_FUNCTIONS_EXPORT_TARGET)
+    endif ()
 
     # Defines
     foreach (DEFINE ${GET_CREATED_DEFINES})
@@ -229,9 +229,9 @@ function (_cmake_unit_get_created_source_file_contents CONTENTS_RETURN
                     set (INCLUDED_AT_GLOBAL_SCOPE TRUE)
                     break ()
 
-                endif ("${INCLUDE_BEGIN}" STREQUAL "${DIR}")
+                endif ()
 
-            endif (DIR_LENGTH LESS INCLUDE_LENGTH)
+            endif ()
 
         endforeach ()
 
@@ -240,7 +240,7 @@ function (_cmake_unit_get_created_source_file_contents CONTENTS_RETURN
             list (APPEND CONTENTS
                   "#include \"${INCLUDE}\"")
 
-        endif (NOT INCLUDED_AT_GLOBAL_SCOPE)
+        endif ()
 
     endforeach ()
 
@@ -260,7 +260,7 @@ function (_cmake_unit_get_created_source_file_contents CONTENTS_RETURN
 
         list (APPEND CONTENTS "${GET_CREATED_PREPEND_CONTENTS}")
 
-    endif (GET_CREATED_PREPEND_CONTENTS)
+    endif ()
 
     # Function definitions, but only if we're a source
     if ("${SOURCE_TYPE}" STREQUAL "SOURCE")
@@ -275,7 +275,7 @@ function (_cmake_unit_get_created_source_file_contents CONTENTS_RETURN
 
         endforeach ()
 
-    endif ("${SOURCE_TYPE}" STREQUAL "SOURCE")
+    endif ()
 
     # End header guard
     if ("${SOURCE_TYPE}" STREQUAL "HEADER")
@@ -283,12 +283,12 @@ function (_cmake_unit_get_created_source_file_contents CONTENTS_RETURN
         list (APPEND CONTENTS
               "#endif")
 
-    endif ("${SOURCE_TYPE}" STREQUAL "HEADER")
+    endif ()
 
     set (${NAME_RETURN} "${GET_CREATED_NAME}" PARENT_SCOPE)
     set (${CONTENTS_RETURN} "${CONTENTS}" PARENT_SCOPE)
 
-endfunction (_cmake_unit_get_created_source_file_contents)
+endfunction ()
 
 function (_cmake_unit_write_out_file_without_semicolons NAME)
 
@@ -303,7 +303,7 @@ function (_cmake_unit_write_out_file_without_semicolons NAME)
     file (WRITE "${CMAKE_CURRENT_SOURCE_DIR}/${NAME}"
           "${CONTENTS}\n")
 
-endfunction (_cmake_unit_write_out_file_without_semicolons)
+endfunction ()
 
 # cmake_unit_write_out_source_file_before_build
 #
@@ -335,7 +335,7 @@ function (cmake_unit_create_source_file_before_build)
     _cmake_unit_write_out_file_without_semicolons ("${NAME}"
                                                    CONTENTS ${CONTENTS})
 
-endfunction (cmake_unit_create_source_file_before_build)
+endfunction ()
 
 # cmake_unit_generate_source_file_during_build
 #
@@ -404,7 +404,7 @@ function (cmake_unit_generate_source_file_during_build TARGET_RETURN)
 
     set (${TARGET_RETURN} "${TARGET_NAME}" PARENT_SCOPE)
 
-endfunction (cmake_unit_generate_source_file_during_build)
+endfunction ()
 
 function (_cmake_unit_create_source_for_simple_target NAME
                                                       SOURCE_LOCATION_RETURN)
@@ -416,7 +416,7 @@ function (_cmake_unit_create_source_for_simple_target NAME
                                                 ${ARGN})
     set (${SOURCE_LOCATION_RETURN} "${SOURCE_LOCATION}" PARENT_SCOPE)
 
-endfunction (_cmake_unit_create_source_for_simple_target)
+endfunction ()
 
 # cmake_unit_create_simple_executable
 #
@@ -441,7 +441,7 @@ function (cmake_unit_create_simple_executable NAME)
                                                  ${CREATE_SOURCE_FUNCTIONS})
     add_executable (${NAME} "${LOCATION}")
 
-endfunction (cmake_unit_create_simple_executable)
+endfunction ()
 
 # cmake_unit_create_simple_library
 #
@@ -458,7 +458,7 @@ function (cmake_unit_create_simple_library NAME TYPE)
     add_library (${NAME} ${TYPE} "${LOCATION}")
     generate_export_header (${NAME})
 
-endfunction (cmake_unit_create_simple_library)
+endfunction ()
 
 # cmake_unit_get_target_location_from_exports
 #
@@ -523,7 +523,7 @@ function (cmake_unit_get_target_location_from_exports EXPORTS
         message (FATAL_ERROR "Error whilst getting location of ${TARGET}\n"
                              "See ${DETERMINE_LOCATION_ERROR_LOG} for details")
 
-    endif (NOT RESULT EQUAL 0)
+    endif ()
 
     file (READ ${DETERMINE_LOCATION_CAPTURE} LOCATION)
     set (${LOCATION_RETURN} "${LOCATION}" PARENT_SCOPE)
@@ -552,7 +552,7 @@ function (cmake_unit_export_cfg_int_dir LOCATION)
     add_custom_target (write_cfg_int_dir_${LOCATION_NAME} ALL
                        SOURCES ${LOCATION})
 
-endfunction (cmake_unit_export_cfg_int_dir)
+endfunction ()
 
 # cmake_unit_import_cfg_int_dir
 #
@@ -575,7 +575,7 @@ function (assert_true VARIABLE)
         message (SEND_ERROR
                  "Expected ${VARIABLE} to be true")
 
-    endif (NOT VARIABLE)
+    endif ()
 
 endfunction ()
 
@@ -586,7 +586,7 @@ function (assert_false VARIABLE)
         message (SEND_ERROR
                  "Expected ${VARIABLE} to be false")
 
-    endif (VARIABLE)
+    endif ()
 
 endfunction ()
 
@@ -598,9 +598,9 @@ function (_target_exists TARGET_NAME RESULT_VARIABLE)
 
         set (${RESULT_VARIABLE} TRUE PARENT_SCOPE)
 
-    endif (TARGET ${TARGET_NAME})
+    endif ()
 
-endfunction (_target_exists)
+endfunction ()
 
 # assert_target_exists
 #
@@ -615,9 +615,9 @@ function (assert_target_exists TARGET_NAME)
         message (SEND_ERROR
                  "Expected ${TARGET_NAME} to be a target")
 
-    endif (NOT RESULT)
+    endif ()
 
-endfunction (assert_target_exists)
+endfunction ()
 
 
 # assert_target_does_not_exist
@@ -633,9 +633,9 @@ function (assert_target_does_not_exist TARGET_NAME)
         message (SEND_ERROR
                  "Expected ${TARGET_NAME} not to be a target")
 
-    endif (RESULT)
+    endif ()
 
-endfunction (assert_target_does_not_exist)
+endfunction ()
 
 function (_string_contains MAIN_STRING SUBSTRING RESULT_VARIABLE)
 
@@ -647,9 +647,9 @@ function (_string_contains MAIN_STRING SUBSTRING RESULT_VARIABLE)
 
         set (${RESULT_VARIABLE} TRUE PARENT_SCOPE)
 
-    endif (NOT POSITION EQUAL -1)
+    endif ()
 
-endfunction (_string_contains)
+endfunction ()
 
 # assert_string_contains
 #
@@ -664,9 +664,9 @@ function (assert_string_contains MAIN_STRING SUBSTRING)
         message (SEND_ERROR
                  "Substring ${SUBSTRING} not found in ${MAIN_STRING}")
 
-    endif (NOT RESULT)
+    endif ()
 
-endfunction (assert_string_contains)
+endfunction ()
 
 # assert_string_does_not_contain
 #
@@ -681,9 +681,9 @@ function (assert_string_does_not_contain MAIN_STRING SUBSTRING)
         message (SEND_ERROR
                  "Substring ${SUBSTRING} not found in ${MAIN_STRING}")
 
-    endif (RESULT)
+    endif ()
 
-endfunction (assert_string_does_not_contain)
+endfunction ()
 
 function (_variable_is VARIABLE TYPE COMPARATOR VALUE RESULT_VARIABLE)
 
@@ -695,7 +695,7 @@ function (_variable_is VARIABLE TYPE COMPARATOR VALUE RESULT_VARIABLE)
 
             set (${RESULT_VARIABLE} TRUE PARENT_SCOPE)
 
-        endif ("${${VARIABLE}}" STR${COMPARATOR} "${VALUE}")
+        endif ()
 
     elseif ("${TYPE}" MATCHES "INTEGER")
 
@@ -703,7 +703,7 @@ function (_variable_is VARIABLE TYPE COMPARATOR VALUE RESULT_VARIABLE)
 
             set (${RESULT_VARIABLE} TRUE PARENT_SCOPE)
 
-        endif ("${${VARIABLE}}" ${COMPARATOR} ${VALUE})
+        endif ()
 
     elseif ("${TYPE}" MATCHES "BOOL")
 
@@ -717,27 +717,27 @@ function (_variable_is VARIABLE TYPE COMPARATOR VALUE RESULT_VARIABLE)
 
                 set (${RESULT_VARIABLE} TRUE PARENT_SCOPE)
 
-            else (${${VARIABLE}} AND ${VALUE})
+            else ()
 
                 set (${RESULT_VARIABLE} FALSE PARENT_SCOPE)
 
-            endif (${${VARIABLE}} AND ${VALUE})
+            endif ()
 
-        else ("${COMPARATOR}" STREQUAL "EQUAL")
+        else ()
 
             message (FATAL_ERROR "No comparators other than EQUAL are supported"
                                  "for comparing BOOL variables")
 
-        endif ("${COMPARATOR}" STREQUAL "EQUAL")
+        endif ()
 
-    else ("${TYPE}" MATCHES "STRING")
+    else ()
 
         message (FATAL_ERROR
                  "Asked to match unknown type ${TYPE}")
 
-    endif ("${TYPE}" MATCHES "STRING")
+    endif ()
 
-endfunction (_variable_is)
+endfunction ()
 
 # assert_variable_is
 #
@@ -763,9 +763,9 @@ function (assert_variable_is VARIABLE TYPE COMPARATOR VALUE)
                  "Expected type ${TYPE} with value ${VALUE}"
                  " but was ${${VARIABLE}}")
 
-    endif (NOT RESULT)
+    endif ()
 
-endfunction (assert_variable_is)
+endfunction ()
 
 # assert_variable_is_not
 #
@@ -791,9 +791,9 @@ function (assert_variable_is_not VARIABLE TYPE COMPARATOR VALUE)
                  "Expected type ${TYPE} with value ${VALUE}"
                  " but was ${${VARIABLE}}")
 
-    endif (RESULT)
+    endif ()
 
-endfunction (assert_variable_is_not)
+endfunction ()
 
 # assert_variable_matches_regex
 #
@@ -807,9 +807,9 @@ function (assert_variable_matches_regex VARIABLE REGEX)
         message (SEND_ERROR
                  "Expected ${VARIABLE} to match ${REGEX}")
 
-    endif (NOT ${VARIABLE} MATCHES ${REGEX})
+    endif ()
 
-endfunction (assert_variable_matches_regex)
+endfunction ()
 
 # assert_variable_does_not_match_regex
 #
@@ -823,9 +823,9 @@ function (assert_variable_does_not_match_regex VARIABLE REGEX)
         message (SEND_ERROR
                  "Expected ${VARIABLE} to not match ${REGEX}")
 
-    endif (${VARIABLE} MATCHES ${REGEX})
+    endif ()
 
-endfunction (assert_variable_does_not_match_regex)
+endfunction ()
 
 # assert_variable_is_defined
 #
@@ -839,9 +839,9 @@ function (assert_variable_is_defined VARIABLE)
         message (SEND_ERROR
                  "${VARIABLE} is not defined")
 
-    endif (NOT DEFINED ${VARIABLE})
+    endif ()
 
-endfunction (assert_variable_is_defined)
+endfunction ()
 
 # assert_variable_is_not_defined
 #
@@ -855,9 +855,9 @@ function (assert_variable_is_not_defined VARIABLE)
         message (SEND_ERROR
                  "${VARIABLE} is defined")
 
-    endif (DEFINED ${VARIABLE})
+    endif ()
 
-endfunction (assert_variable_is_not_defined)
+endfunction ()
 
 function (_command_executes_with_success RESULT_VARIABLE
                                          ERROR_VARIABLE
@@ -881,12 +881,12 @@ function (_command_executes_with_success RESULT_VARIABLE
 
         set (${RESULT_VARIABLE} TRUE PARENT_SCOPE)
 
-    endif (RESULT EQUAL 0)
+    endif ()
 
     set (${ERROR_VARIABLE} ${ERROR} PARENT_SCOPE)
     set (${CODE_VARIABLE} ${RESULT} PARENT_SCOPE)
 
-endfunction (_command_executes_with_success)
+endfunction ()
 
 # assert_command_executes_with_success
 #
@@ -907,9 +907,9 @@ function (assert_command_executes_with_success)
                  "The command ${ARGN} failed with result "
                  " ${CODE} : ${ERROR}\n")
 
-    endif (NOT RESULT)
+    endif ()
 
-endfunction (assert_command_executes_with_success)
+endfunction ()
 
 # assert_command_does_not_execute_with_success
 #
@@ -928,9 +928,9 @@ function (assert_command_does_not_execute_with_success)
                  "The command ${ARGN} succeeded with result "
                  " ${RESULT}\n")
 
-    endif (RESULT)
+    endif ()
 
-endfunction (assert_command_does_not_execute_with_success)
+endfunction ()
 
 function (_lib_found_in_libraries LIBRARY RESULT_VARIABLE)
 
@@ -948,11 +948,11 @@ function (_lib_found_in_libraries LIBRARY RESULT_VARIABLE)
 
             set (${RESULT_VARIABLE} TRUE PARENT_SCOPE)
 
-        endif (_lib MATCHES "(^.*${LIBRARY}.*$)")
+        endif ()
 
     endforeach ()
 
-endfunction (_lib_found_in_libraries)
+endfunction ()
 
 function (_print_all_target_libraries TARGET)
 
@@ -967,15 +967,15 @@ function (_print_all_target_libraries TARGET)
 
         message (STATUS "Part of link interface: " ${_lib})
 
-    endforeach (${_lib})
+    endforeach ()
 
     foreach (_lib ${LINK_LIBRARIES})
 
         message (STATUS "Link library: " ${_lib})
 
-    endforeach (${_lib})
+    endforeach ()
 
-endfunction (_print_all_target_libraries)
+endfunction ()
 
 function (_target_is_linked_to TARGET_NAME
                                LIBRARY
@@ -997,13 +997,13 @@ function (_target_is_linked_to TARGET_NAME
 
         set (${RESULT_VARIABLE} TRUE PARENT_SCOPE)
 
-    else (FOUND_IN_INTERFACE OR FOUND_IN_LINK)
+    else ()
 
         set (${RESULT_VARIABLE} FALSE PARENT_SCOPE)
 
-    endif (FOUND_IN_INTERFACE OR FOUND_IN_LINK)
+    endif ()
 
-endfunction (_target_is_linked_to)
+endfunction ()
 
 # assert_target_is_linked_to
 #
@@ -1023,9 +1023,9 @@ function (assert_target_is_linked_to TARGET_NAME LIBRARY)
 
         _print_all_target_libraries (${TARGET_NAME})
 
-    endif (NOT RESULT)
+    endif ()
 
-endfunction (assert_target_is_linked_to)
+endfunction ()
 
 # assert_target_is_not_linked_to
 #
@@ -1046,9 +1046,9 @@ function (assert_target_is_not_linked_to TARGET_NAME LIBRARY)
 
         _print_all_target_libraries (${TARGET_NAME})
 
-    endif (RESULT)
+    endif ()
 
-endfunction (assert_target_is_not_linked_to)
+endfunction ()
 
 function (_item_has_property_with_value ITEM_TYPE
                                         ITEM
@@ -1064,7 +1064,7 @@ function (_item_has_property_with_value ITEM_TYPE
 
         set (ITEM)
 
-    endif (ITEM_TYPE STREQUAL "GLOBAL")
+    endif ()
 
     get_property (_property_value
                   ${ITEM_TYPE} ${ITEM}
@@ -1078,7 +1078,7 @@ function (_item_has_property_with_value ITEM_TYPE
 
     set (${RESULT_VARIABLE} ${RESULT} PARENT_SCOPE)
 
-endfunction (_item_has_property_with_value)
+endfunction ()
 
 # assert_has_property_with_value
 #
@@ -1106,9 +1106,9 @@ function (assert_has_property_with_value ITEM_TYPE
                  "Expected ${ITEM_TYPE} ${ITEM} to have property ${PROPERTY} "
                  " of type ${PROPERTY_TYPE} with value ${VALUE}")
 
-    endif (NOT RESULT)
+    endif ()
 
-endfunction (assert_has_property_with_value)
+endfunction ()
 
 # assert_does_not_have_property_with_value
 #
@@ -1137,9 +1137,9 @@ function (assert_does_not_have_property_with_value ITEM_TYPE
                  "Expected ${ITEM_TYPE} ${ITEM} not to have property"
                  " ${PROPERTY} of type ${PROPERTY_TYPE} with value ${VALUE}")
 
-    endif (RESULT)
+    endif ()
 
-endfunction (assert_does_not_have_property_with_value)
+endfunction ()
 
 function (_list_contains_value LIST_VARIABLE
                                TYPE
@@ -1162,11 +1162,11 @@ function (_list_contains_value LIST_VARIABLE
 
             set (${RESULT_VARIABLE} TRUE PARENT_SCOPE)
 
-        endif (RESULT)
+        endif ()
 
     endforeach ()
 
-endfunction (_list_contains_value)
+endfunction ()
 
 # assert_list_contains_value
 #
@@ -1189,9 +1189,9 @@ function (assert_list_contains_value LIST_VARIABLE
         message (SEND_ERROR "List ${LIST_VARIABLE} does not contain a value "
                             "${COMPARATOR} ${VALUE}")
 
-    endif (NOT RESULT)
+    endif ()
 
-endfunction (assert_list_contains_value)
+endfunction ()
 
 # assert_list_contains_value
 #
@@ -1213,9 +1213,9 @@ function (assert_list_does_not_contain_value LIST_VARIABLE
         message (SEND_ERROR "List ${LIST_VARIABLE} contains a value "
                             "${COMPARATOR} ${VALUE}")
 
-    endif (RESULT)
+    endif ()
 
-endfunction (assert_list_does_not_contain_value)
+endfunction ()
 
 function (_item_has_property_containing_value ITEM_TYPE
                                               ITEM
@@ -1233,7 +1233,7 @@ function (_item_has_property_containing_value ITEM_TYPE
 
         set (ITEM)
 
-    endif (ITEM_TYPE STREQUAL "GLOBAL")
+    endif ()
 
     get_property (_property_values
                   ${ITEM_TYPE} ${ITEM}
@@ -1249,9 +1249,9 @@ function (_item_has_property_containing_value ITEM_TYPE
 
         set (${RESULT_VARIABLE} TRUE PARENT_SCOPE)
 
-    endif (RESULT)
+    endif ()
 
-endfunction (_item_has_property_containing_value)
+endfunction ()
 
 # assert_has_property_containing_value
 #
@@ -1279,9 +1279,9 @@ function (assert_has_property_containing_value ITEM_TYPE
                  "Expected ${ITEM_TYPE} ${ITEM} to have property ${PROPERTY} "
                  " of type ${PROPERTY_TYPE} containing value ${VALUE}")
 
-    endif (NOT RESULT)
+    endif ()
 
-endfunction (assert_has_property_containing_value)
+endfunction ()
 
 # assert_does_not_have_property_containing_value
 #
@@ -1310,9 +1310,9 @@ function (assert_does_not_have_property_containing_value ITEM_TYPE
                  "${PROPERTY} of type ${PROPERTY_TYPE} containing "
                  "value ${VALUE}")
 
-    endif (RESULT)
+    endif ()
 
-endfunction (assert_does_not_have_property_containing_value)
+endfunction ()
 
 function (_file_exists FILE RESULT_VARIABLE)
 
@@ -1322,9 +1322,9 @@ function (_file_exists FILE RESULT_VARIABLE)
 
         set (${RESULT_VARIABLE} FALSE PARENT_SCOPE)
 
-    endif (NOT EXISTS ${FILE})
+    endif ()
 
-endfunction (_file_exists)
+endfunction ()
 
 # assert_file_exists:
 #
@@ -1338,9 +1338,9 @@ function (assert_file_exists FILE)
 
         message (SEND_ERROR "The file ${FILE} does not exist")
 
-    endif (NOT RESULT)
+    endif ()
 
-endfunction (assert_file_exists)
+endfunction ()
 
 # assert_file_does_not_exist:
 #
@@ -1354,9 +1354,9 @@ function (assert_file_does_not_exist FILE)
 
         message (SEND_ERROR "The file ${FILE} does exist")
 
-    endif (RESULT)
+    endif ()
 
-endfunction (assert_file_does_not_exist)
+endfunction ()
 
 function (_file_contains_substring FILE SUBSTRING RESULT_VARIABLE)
 
@@ -1368,7 +1368,7 @@ function (_file_contains_substring FILE SUBSTRING RESULT_VARIABLE)
     # propogate the result here too
     set (${RESULT_VARIABLE} ${RESULT} PARENT_SCOPE)
 
-endfunction (_file_contains_substring)
+endfunction ()
 
 # assert_file_contains:
 #
@@ -1383,9 +1383,9 @@ function (assert_file_contains FILE SUBSTRING)
         message (SEND_ERROR "The file ${FILE} does not contain the string "
                  " ${SUBSTRING}")
 
-    endif (NOT RESULT)
+    endif ()
 
-endfunction (assert_file_contains)
+endfunction ()
 
 # assert_file_does_not_contain:
 #
@@ -1399,9 +1399,9 @@ function (assert_file_does_not_contain FILE SUBSTRING)
 
         message (SEND_ERROR "The file ${FILE} contains the string ${SUBSTRING}")
 
-    endif (RESULT)
+    endif ()
 
-endfunction (assert_file_does_not_contain)
+endfunction ()
 
 function (_file_has_line_matching FILE PATTERN RESULT_VARIABLE)
 
@@ -1421,11 +1421,11 @@ function (_file_has_line_matching FILE PATTERN RESULT_VARIABLE)
             set (${RESULT_VARIABLE} TRUE PARENT_SCOPE)
             break ()
 
-        endif (LINE MATCHES ${PATTERN})
+        endif ()
 
     endforeach ()
 
-endfunction (_file_has_line_matching)
+endfunction ()
 
 # assert_file_has_line_matching
 #
@@ -1440,7 +1440,7 @@ function (assert_file_has_line_matching FILE PATTERN)
         message (SEND_ERROR "The file ${FILE} does not have "
                  "a line matching ${PATTERN}")
 
-    endif (NOT RESULT)
+    endif ()
 
 endfunction ()
 
@@ -1457,6 +1457,6 @@ function (assert_file_does_not_have_line_matching FILE PATTERN)
         message (SEND_ERROR "The file ${FILE} has "
                  "a line matching ${PATTERN}")
 
-    endif (RESULT)
+    endif ()
 
 endfunction ()

--- a/CMakeUnitRunner.cmake
+++ b/CMakeUnitRunner.cmake
@@ -45,7 +45,7 @@ if (CMAKE_UNIT_LOG_COVERAGE)
     set (CMAKE_UNIT_COVERAGE_FILE
          "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}.trace")
 
-endif (CMAKE_UNIT_LOG_COVERAGE)
+endif ()
 
 set (_RUNNER_LIST_DIR "${CMAKE_CURRENT_LIST_DIR}")
 # bootstrap_cmake_unit
@@ -115,9 +115,9 @@ function (bootstrap_cmake_unit)
         # Clobber the coverage report
         file (WRITE "${CMAKE_UNIT_COVERAGE_FILE}" "")
 
-    endif (CMAKE_UNIT_LOG_COVERAGE)
+    endif ()
 
-endfunction (bootstrap_cmake_unit)
+endfunction ()
 
 macro (_define_variables_for_test TEST_NAME)
 
@@ -130,7 +130,7 @@ macro (_define_variables_for_test TEST_NAME)
     set (TEST_INITIAL_CACHE_FILE
          "${TEST_DIRECTORY_NAME}/initial_cache.cmake")
 
-endmacro (_define_variables_for_test)
+endmacro ()
 
 function (_bootstrap_test_driver_script TEST_NAME
                                         PARENT_DRIVER_SCRIPT_CONTENTS)
@@ -203,16 +203,17 @@ function (_bootstrap_test_driver_script TEST_NAME
          "        message (FATAL_ERROR \n"
          "                 \"The command \${STRINGIFIED_COMMAND}\"\n"
          "                 \" failed with \${RESULT}\")\n"
-         "    endif (NOT RESULT EQUAL 0 AND NOT ADD_COMMAND_ALLOW_FAIL)\n"
+         "    endif ()\n"
          "    set (\${OUTPUT_RETURN} \${OUTPUT_LINES} PARENT_SCOPE)\n"
          "    set (\${ERROR_RETURN} \${ERROR_LINES} PARENT_SCOPE)\n"
          "    set (\${RESULT_RETURN} \"\${RESULT}\" PARENT_SCOPE)\n"
-         "endfunction (add_driver_command)\n")
+         "endfunction ()\n"
+         "\n")
 
     set (${PARENT_DRIVER_SCRIPT_CONTENTS} ${DRIVER_SCRIPT_CONTENTS}
          PARENT_SCOPE)
 
-endfunction (_bootstrap_test_driver_script)
+endfunction ()
 
 function (_add_driver_step ADD_STEP_PARENT_DRIVER_SCRIPT_CONTENTS STEP)
 
@@ -229,17 +230,17 @@ function (_add_driver_step ADD_STEP_PARENT_DRIVER_SCRIPT_CONTENTS STEP)
 
         message (FATAL_ERROR "A COMMAND must be provided to add_driver_step")
 
-    endif (NOT ADD_DRIVER_STEP_COMMAND)
+    endif ()
 
     if (ADD_DRIVER_STEP_ALLOW_FAIL)
 
         set (ALLOW_FAIL ALLOW_FAIL)
 
-    else (ADD_DRIVER_STEP_ALLOW_FAIL)
+    else ()
 
         set (ALLOW_FAIL "")
 
-    endif (ADD_DRIVER_STEP_ALLOW_FAIL)
+    endif ()
 
     # When we pass ADD_DRIVER_STEP_COMMAND into this string, it will appear to
     # just be a space-separated string, which will have each element converted
@@ -267,7 +268,7 @@ function (_add_driver_step ADD_STEP_PARENT_DRIVER_SCRIPT_CONTENTS STEP)
     set (${ADD_STEP_PARENT_DRIVER_SCRIPT_CONTENTS} ${DRIVER_SCRIPT_CONTENTS}
          PARENT_SCOPE)
 
-endfunction (_add_driver_step)
+endfunction ()
 
 function (_define_test_for_driver TEST_NAME DRIVER_SCRIPT)
 
@@ -282,7 +283,7 @@ function (_define_test_for_driver TEST_NAME DRIVER_SCRIPT)
 
         message (FATAL_ERROR "Test driver script must have contents")
 
-    endif (NOT DEFINE_TEST_FOR_DRIVER_CONTENTS)
+    endif ()
 
     # Write driver script, but see below:
     string (REPLACE "@SEMICOLON@" "\;" DEFINE_TEST_FOR_DRIVER_CONTENTS
@@ -309,7 +310,7 @@ function (_define_test_for_driver TEST_NAME DRIVER_SCRIPT)
               ${CMAKE_COMMAND} -P "${DRIVER_SCRIPT}"
               WORKING_DIRECTORY "${TEST_DIRECTORY_NAME}")
 
-endfunction (_define_test_for_driver)
+endfunction ()
 
 function (_append_clean_step PARENT_DRIVER_SCRIPT_CONTENTS
                              TEST_WORKING_DIRECTORY_NAME)
@@ -321,7 +322,7 @@ function (_append_clean_step PARENT_DRIVER_SCRIPT_CONTENTS
     set (${PARENT_DRIVER_SCRIPT_CONTENTS} ${DRIVER_SCRIPT_CONTENTS}
          PARENT_SCOPE)
 
-endfunction (_append_clean_step)
+endfunction ()
 
 function (_append_configure_step TEST_NAME
                                  PARENT_DRIVER_SCRIPT_CONTENTS
@@ -349,10 +350,10 @@ function (_append_configure_step TEST_NAME
              "cmake_minimum_required (VERSION 2.8 FATAL_ERROR)\n"
              "if (POLICY CMP0042)\n"
              "  cmake_policy (SET CMP0042 NEW)\n"
-             "endif (POLICY CMP0042)\n"
+             "endif ()\n"
              "if (POLICY CMP0025)\n"
              "  cmake_policy (SET CMP0025 NEW)\n"
-             "endif (POLICY CMP0025)\n"
+             "endif ()\n"
              "project (TestProject CXX C)\n"
              "include (\"${CMAKE_CURRENT_SOURCE_DIR}/${TEST_FILE}\")\n")
 
@@ -366,7 +367,7 @@ function (_append_configure_step TEST_NAME
 
             set (ALLOW_FAIL_OPTION ALLOW_FAIL)
 
-        endif (CONFIGURE_STEP_ALLOW_FAIL)
+        endif ()
 
         # Set GENERATOR
         string (REPLACE " " "\\ " GENERATOR ${CMAKE_GENERATOR})
@@ -381,19 +382,19 @@ function (_append_configure_step TEST_NAME
 
             set (TRACE_OPTION "--trace")
 
-        endif (CMAKE_UNIT_LOG_COVERAGE)
+        endif ()
 
         if (NOT CMAKE_UNIT_NO_UNINITIALIZED_WARNINGS)
 
             set (UNINITIALIZED_OPTION "--warn-uninitialized")
 
-        endif (NOT CMAKE_UNIT_NO_UNINITIALIZED_WARNINGS)
+        endif ()
 
         if (NOT CMAKE_UNIT_NO_DEV_WARNINGS)
 
             set (DEVELOPER_WARNINGS_OPTION "-Wdev")
 
-        endif (NOT CMAKE_UNIT_NO_DEV_WARNINGS)
+        endif ()
 
         set (CONFIGURE_COMMAND
              "${CMAKE_COMMAND}"
@@ -420,10 +421,11 @@ function (_append_configure_step TEST_NAME
                   "    if (\"\${LINE}\" MATCHES \"^CMake Warning.*\")\n"
                   "        message (SEND_ERROR\n"
                   "                 \"CMake Warnings were present!\")\n"
-                  "    endif (\"\${LINE}\" MATCHES \"^CMake Warning.*\")\n"
-                  "endforeach ()\n")
+                  "    endif ()\n"
+                  "endforeach ()\n"
+                  "\n")
 
-        endif (NOT CONFIGURE_STEP_ALLOW_WARNINGS)
+        endif ()
 
         # After we've added the driver step, read back CONFIGURE.error and
         # VERIFY.error and filter through each of the lines to find
@@ -491,19 +493,19 @@ function (_append_configure_step TEST_NAME
                   "file (APPEND \"${CMAKE_UNIT_COVERAGE_FILE}\"\n"
                   "      \${COVERAGE_FILE_CONTENTS})\n")
 
-        endif (CMAKE_UNIT_LOG_COVERAGE)
+        endif ()
 
         set (${PARENT_DRIVER_SCRIPT_CONTENTS} ${DRIVER_SCRIPT_CONTENTS}
              PARENT_SCOPE)
 
-    else (EXISTS ${TEST_FILE_PATH})
+    else ()
 
         message (SEND_ERROR "The file ${TEST_FILE_PATH} must exist"
                             " in order for the configure step to run")
 
-    endif (EXISTS ${TEST_FILE_PATH})
+    endif ()
 
-endfunction (_append_configure_step)
+endfunction ()
 
 function (_append_build_step PARENT_DRIVER_SCRIPT_CONTENTS
                              TEST_WORKING_DIRECTORY_NAME
@@ -523,7 +525,7 @@ function (_append_build_step PARENT_DRIVER_SCRIPT_CONTENTS
 
         set (ALLOW_FAIL_OPTION ALLOW_FAIL)
 
-    endif (BUILD_STEP_ALLOW_FAIL)
+    endif ()
 
     # The "all" target is special. It means "do whatever happens by
     # default". Some build systems literally have a target called
@@ -533,17 +535,17 @@ function (_append_build_step PARENT_DRIVER_SCRIPT_CONTENTS
 
         set (TARGET_OPTION "")
 
-    else ("${TARGET}" STREQUAL "all")
+    else ()
 
         set (TARGET_OPTION --target ${TARGET})
 
-    endif ("${TARGET}" STREQUAL "all")
+    endif ()
 
     if ("${CMAKE_MAKE_PROGRAM}" MATCHES ".*ninja.*")
 
         set (BUILD_TOOL_VERBOSE_OPTION "-v")
 
-    endif ("${CMAKE_MAKE_PROGRAM}" MATCHES ".*ninja.*")
+    endif ()
 
     set (BUILD_COMMAND "${CMAKE_COMMAND}"
                        --build
@@ -558,7 +560,7 @@ function (_append_build_step PARENT_DRIVER_SCRIPT_CONTENTS
     set (${PARENT_DRIVER_SCRIPT_CONTENTS} ${DRIVER_SCRIPT_CONTENTS}
          PARENT_SCOPE)
 
-endfunction (_append_build_step)
+endfunction ()
 
 function (_append_test_step PARENT_DRIVER_SCRIPT_CONTENTS)
 
@@ -576,7 +578,7 @@ function (_append_test_step PARENT_DRIVER_SCRIPT_CONTENTS)
 
         set (ALLOW_FAIL_OPTION ALLOW_FAIL)
 
-    endif (TEST_STEP_ALLOW_FAIL)
+    endif ()
 
     set (TEST_COMMAND "${CMAKE_CTEST_COMMAND}"
                        -C Debug
@@ -588,7 +590,7 @@ function (_append_test_step PARENT_DRIVER_SCRIPT_CONTENTS)
     set (${PARENT_DRIVER_SCRIPT_CONTENTS} ${DRIVER_SCRIPT_CONTENTS}
          PARENT_SCOPE)
 
-endfunction (_append_test_step)
+endfunction ()
 
 function (_append_verify_step PARENT_DRIVER_SCRIPT_CONTENTS
                               CACHE_FILE)
@@ -603,7 +605,7 @@ function (_append_verify_step PARENT_DRIVER_SCRIPT_CONTENTS
 
             set (TRACE_OPTION "--trace")
 
-        endif (CMAKE_UNIT_LOG_COVERAGE)
+        endif ()
 
         set (VERIFY_COMMAND
              "${CMAKE_COMMAND}"
@@ -616,14 +618,14 @@ function (_append_verify_step PARENT_DRIVER_SCRIPT_CONTENTS
         set (${PARENT_DRIVER_SCRIPT_CONTENTS} ${DRIVER_SCRIPT_CONTENTS}
              PARENT_SCOPE)
 
-    else (EXISTS ${TEST_VERIFY_SCRIPT_FILE})
+    else ()
 
         message (SEND_ERROR "The file ${TEST_VERIFY_SCRIPT_FILE} must exist"
                             " in order for the verify step to run")
 
-    endif (EXISTS ${TEST_VERIFY_SCRIPT_FILE})
+    endif ()
 
-endfunction (_append_verify_step)
+endfunction ()
 
 function (_append_coverage_step PARENT_DRIVER_SCRIPT_CONTENTS)
 
@@ -631,7 +633,7 @@ function (_append_coverage_step PARENT_DRIVER_SCRIPT_CONTENTS)
 
         return ()
 
-    endif (NOT CMAKE_UNIT_LOG_COVERAGE)
+    endif ()
 
     # We need to make sure that the quotes around our coverage
     # files get passed back down to the driver script
@@ -698,7 +700,7 @@ function (_append_coverage_step PARENT_DRIVER_SCRIPT_CONTENTS)
     set (${PARENT_DRIVER_SCRIPT_CONTENTS}
          ${DRIVER_SCRIPT_CONTENTS} PARENT_SCOPE)
 
-endfunction (_append_coverage_step)
+endfunction ()
 
 # add_cmake_test:
 #
@@ -723,7 +725,7 @@ function (add_cmake_test TEST_NAME)
                              "${TEST_DRIVER_SCRIPT}"
                              CONTENTS ${TEST_DRIVER_SCRIPT_CONTENTS})
 
-endfunction (add_cmake_test PARENT_DRIVER_SCRIPT_CONTENTS)
+endfunction ()
 
 # add_cmake_build_test:
 #
@@ -756,33 +758,33 @@ function (add_cmake_build_test TEST_NAME VERIFY)
 
         set (ADD_CMAKE_BUILD_TEST_TARGET all)
 
-    endif (NOT ADD_CMAKE_BUILD_TEST_TARGET)
+    endif ()
 
     if (ADD_CMAKE_BUILD_TEST_ALLOW_CONFIGURE_WARNINGS)
 
         set (ALLOW_CONFIGURE_WARNINGS_OPTION ALLOW_WARNINGS)
 
-    endif (ADD_CMAKE_BUILD_TEST_ALLOW_CONFIGURE_WARNINGS)
+    endif ()
 
     if (ADD_CMAKE_BUILD_TEST_ALLOW_CONFIGURE_FAIL)
 
         set (ALLOW_CONFIGURE_FAIL_OPTION ALLOW_FAIL)
         set (ADD_CMAKE_BUILD_TEST_ALLOW_BUILD_FAIL ON)
 
-    endif (ADD_CMAKE_BUILD_TEST_ALLOW_CONFIGURE_FAIL)
+    endif ()
 
     if (ADD_CMAKE_BUILD_TEST_ALLOW_BUILD_FAIL)
 
         set (ALLOW_BUILD_FAIL_OPTION ALLOW_FAIL)
         set (ADD_CMAKE_BUILD_TEST_ENSURE_TEST_SUCCESS OFF)
 
-    endif (ADD_CMAKE_BUILD_TEST_ALLOW_BUILD_FAIL)
+    endif ()
 
     if (ADD_CMAKE_BUILD_TEST_ALLOW_TEST_FAIL)
 
         set (ALLOW_TEST_FAIL_OPTION ALLOW_FAIL)
 
-    endif (ADD_CMAKE_BUILD_TEST_ALLOW_TEST_FAIL)
+    endif ()
 
     _define_variables_for_test (${TEST_NAME})
     _bootstrap_test_driver_script(${TEST_NAME}
@@ -794,7 +796,7 @@ function (add_cmake_build_test TEST_NAME VERIFY)
       _append_clean_step (TEST_DRIVER_SCRIPT_CONTENTS
                           "${TEST_WORKING_DIRECTORY_NAME}")
 
-    endif (NOT ADD_CMAKE_BUILD_TEST_NO_CLEAN)
+    endif ()
 
     _append_configure_step (${TEST_NAME}
                             TEST_DRIVER_SCRIPT_CONTENTS
@@ -814,7 +816,7 @@ function (add_cmake_build_test TEST_NAME VERIFY)
                             ${ALLOW_BUILD_FAIL_OPTION}
                             ${NO_CLEAN_OPTION})
 
-    endif (NOT ADD_CMAKE_BUILD_TEST_ALLOW_CONFIGURE_FAIL)
+    endif ()
 
     # Can't test the project if the build step is allowed to fail
     if (NOT ADD_CMAKE_BUILD_TEST_ALLOW_BUILD_FAIL)
@@ -822,7 +824,7 @@ function (add_cmake_build_test TEST_NAME VERIFY)
         _append_test_step (TEST_DRIVER_SCRIPT_CONTENTS
                            ${ALLOW_TEST_FAIL_OPTION})
 
-    endif (NOT ADD_CMAKE_BUILD_TEST_ALLOW_BUILD_FAIL)
+    endif ()
 
     _append_verify_step (TEST_DRIVER_SCRIPT_CONTENTS
                          "${TEST_INITIAL_CACHE_FILE}")
@@ -831,4 +833,4 @@ function (add_cmake_build_test TEST_NAME VERIFY)
                              "${TEST_DRIVER_SCRIPT}"
                              CONTENTS ${TEST_DRIVER_SCRIPT_CONTENTS})
 
-endfunction (add_cmake_build_test)
+endfunction ()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ if (POLICY CMP0025)
 
     cmake_policy (SET CMP0025 NEW)
 
-endif (POLICY CMP0025)
+endif ()
 
 project (CMakeUnitTests)
 cmake_minimum_required (VERSION 2.8)

--- a/tests/FileForCoverage.cmake
+++ b/tests/FileForCoverage.cmake
@@ -16,7 +16,7 @@ function (my_function ARG_ONE # Executable
         message ("Executable line with \n carriage return") # Executable
         # Line 17 not executable - SlashNDoesntBreakLines
 
-    endif (ARGUMENT_ONE) # Not executable - LinesStartingWithEndNotExecutable
+    endif () # Not executable - LinesStartingWithEndNotExecutable
 
     set (LIST ARGUMENT_ONE # Executable
               ARGUMENT_TWO) # Not executable - LinesUntilCloseBraceNotExecutable


### PR DESCRIPTION
The previous convention was to put this information in else (),
endmacro (), endif (), endfunction () etc blocks. This was bad practice.

Remove all instances of this and make cmakelint catch any new instances
of it.
