### PR TITLE
Handle multiple COMMAND lists passed to add_custom_command

### DIFF
--- a/tests/CMakeTestsHaveVerboseOutput.cmake
+++ b/tests/CMakeTestsHaveVerboseOutput.cmake
@@ -13,17 +13,21 @@ set (TEST_NAME_VERIFY "SampleTestVerify")
 set (TEST_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${TEST_NAME}.cmake")
 set (TEST_VERIFY_FILE "${CMAKE_CURRENT_SOURCE_DIR}/${TEST_NAME_VERIFY}.cmake")
 
-set (SOURCE_FILE "${CMAKE_CURRENT_BINARY_DIR}/Source.cpp")
 set (GENERATED_FILE "${CMAKE_CURRENT_BINARY_DIR}/Generated.cpp")
 
-file (WRITE "${SOURCE_FILE}" "")
 file (WRITE "${TEST_FILE}"
       "include (CMakeUnit)\n"
       "add_custom_command (OUTPUT\n"
       "                    \"${GENERATED_FILE}\"\n"
+      # The two commands will actually be to generate a
+      # file called FirstCommand.cpp, and then another
+      # command to generate SecondCommand.cpp
       "                    COMMAND\n"
       "                    \"${CMAKE_COMMAND}\" -E touch\n"
-      "                    \"${GENERATED_FILE}\")\n"
+      "                    \"${CMAKE_CURRENT_BINARY_DIR}/FirstCommand.cpp\"\n"
+      "                    COMMAND\n"
+      "                    \"${CMAKE_COMMAND}\" -E touch\n"
+      "                    \"${CMAKE_CURRENT_BINARY_DIR}/SecondCommand.cpp\")\n"
       "add_custom_target (custom_target ALL\n"
       "                   SOURCES \"${GENERATED_FILE}\")\n")
 file (WRITE "${TEST_VERIFY_FILE}" "")

--- a/tests/CMakeTestsHaveVerboseOutputVerify.cmake
+++ b/tests/CMakeTestsHaveVerboseOutputVerify.cmake
@@ -12,7 +12,12 @@ cmake_unit_escape_string ("${CMAKE_COMMAND}" ESCAPED_CMAKE_COMMAND)
 
 set (TEST_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/TEST.output")
 
-set (CUSTOM_COMMAND_CMAKE_REGEX
-     "^.*${ESCAPED_CMAKE_COMMAND} -E touch .*Generated.cpp.*$")
+set (FIRST_CUSTOM_COMMAND_CMAKE_REGEX
+     "^.*${ESCAPED_CMAKE_COMMAND}.*-E touch .*FirstCommand.cpp.*$")
 assert_file_has_line_matching ("${TEST_OUTPUT}"
-                               "${CUSTOM_COMMAND_CMAKE_REGEX}")
+                               "${FIRST_CUSTOM_COMMAND_CMAKE_REGEX}")
+
+set (SECOND_CUSTOM_COMMAND_CMAKE_REGEX
+     "^.*${ESCAPED_CMAKE_COMMAND}.*-E touch .*SecondCommand.cpp.*$")
+assert_file_has_line_matching ("${TEST_OUTPUT}"
+                               "${SECOND_CUSTOM_COMMAND_CMAKE_REGEX}")


### PR DESCRIPTION
Also use additional COMMANDs when calling _add_custom_command to
perform printing of passed COMMANDs rather than a custom target
