### PR TITLE
Some optimizations that substantially reduce test runtime.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,22 +186,16 @@ options you specify.
 
 #### Discovering tests and running them ####
 
-Tests can be discovered by using the `cmake_unit_discover_tests_in` function.
-Namespace should be set to the namespace that your tests live in (each test
-function name is prefixed by its namespace). RETURN_LIST is a variable that
-stores the discovered test names. You can add further tests to this list
-if they're not trivial to auto-discover (for instance, they are
-table-generated).
-
 `cmake_unit_init` is what handles the registration and running of each
-discovered test function. It takes a list of test function names as the
-value to its `TESTS` keyword argument. It also takes a list of files considered
-to be candidates for code coverage as `COVERAGE_FILES`.
+discovered test function. It takes a namespace as the argument to the keyword
+NAMESPACE. This is the name each test is prefixed with (followed by _test).
+Any function matching the pattern ^${namespace}_test_.*$ will be automatically
+registered. It also takes a list of files considered to be candidates for
+code coverage as `COVERAGE_FILES`.
 
 As an example, see the following:
 
-    cmake_unit_discover_tests_in (namespace ALL_TESTS)
-    cmake_unit_init (TESTS ${ALL_TESTS}
+    cmake_unit_init (NAMESPACE namespace
                      COVERAGE_FILES "${PROJECT_DIR}/Module.cmake")
 
 ### CMakeUnit ###

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -160,9 +160,7 @@ function (_cmake_unit_test_gen_discover_from_contents)
           "set (NEXT_TESTS)\n"
           "set (CMAKE_UNIT_PARENT_BINARY_DIR\n"
           "     \"${CMAKE_CURRENT_BINARY_DIR}\")\n"
-          "cmake_unit_discover_tests_in (\"${GEN_DISCOVER_NAMESPACE}\"\n"
-          "                              NEXT_TESTS)\n"
-          "cmake_unit_init (TESTS \${NEXT_TESTS}\n"
+          "cmake_unit_init (NAMESPACE \"${GEN_DISCOVER_NAMESPACE}\"\n"
           "                 ${INIT_OPTIONS})\n")
 
     file (WRITE "${AUX_CMAKELISTS_FILE}"
@@ -2275,8 +2273,7 @@ function (cmake_unit_test_missed_lines_have_non_zero_d_a_counter)
 
 endfunction ()
 
-cmake_unit_discover_tests_in ("cmake_unit" ALL_TESTS)
-cmake_unit_init (TESTS ${ALL_TESTS}
+cmake_unit_init (NAMESPACE "cmake_unit"
                  COVERAGE_FILES
                  "${CMAKE_UNIT_DIRECTORY}/CMakeUnitRunner.cmake"
                  "${CMAKE_UNIT_DIRECTORY}/CMakeTraceToLCov.cmake"


### PR DESCRIPTION
We spent a substantial amount of time computing test lists and
dispatch tables. This ocurred multiple times every single time
CMakeLists.txt was re-entered and was effectively redundant work
as the value would be the same every time. Cache the values
of these lists and tables as global properties and pass them to
each CMake invocation.

Removed cmake_unit_discover_tests and instead folded test
detection in a namespace into the NAMESPACE keyword of
cmake_unit_init. Given that we can dynamically look up command
names at runtime, there isn't much need for a separate function
in the API to discover tests anymore.