### PR TITLE
Wrap Driver.cmake so that we can get coverage on CMakeUnitRunner.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: cpp
 sudo: false
 cache:
-- ~/container
+  directories:
+    - ~/container
 env:
 - CMAKE_GENERATOR="Unix Makefiles" CMAKE_VERSION="master"
 - CMAKE_GENERATOR="Ninja" CMAKE_VERSION="master"
@@ -9,6 +10,7 @@ env:
 - CMAKE_GENERATOR="Ninja" CMAKE_VERSION="3.0.2"
 - CMAKE_GENERATOR="Unix Makefiles" CMAKE_VERSION="2.8.12"
 - CMAKE_GENERATOR="Ninja" CMAKE_VERSION="2.8.12"
+- CMAKE_GENERATOR="Unix Makefiles" CMAKE_VERSION="master" COVERAGE=ON
 before_install:
 # Setup python so that we can install packages on pip.
 - wget public-travis-scripts.polysquare.org/setup-lang.sh

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -159,6 +159,7 @@ function (_cmake_unit_test_gen_discover_from_contents)
           "set (NEXT_TESTS)\n"
           "set (CMAKE_UNIT_PARENT_BINARY_DIR\n"
           "     \"${CMAKE_CURRENT_BINARY_DIR}\")\n"
+          "set (_CMAKE_UNIT_INTERNAL_TESTING ON CACHE BOOL \"\" FORCE)\n"
           "cmake_unit_init (NAMESPACE \"${GEN_DISCOVER_NAMESPACE}\"\n"
           "                 ${INIT_OPTIONS})\n")
 


### PR DESCRIPTION
CMakeUnitRunner gets executed in script mode, so we need to forward
on trace results from it on to our actual coverage file.
