### PR TITLE
Ensure that paths are quoted even in generated files.

### DIFF
--- a/CMakeUnit.cmake
+++ b/CMakeUnit.cmake
@@ -524,6 +524,7 @@ endfunction ()
 # TARGET: Name of TARGET as it will be found in the EXPORTS file
 # LOCATION_RETURN: Variable to write target's LOCATION property into.
 function (cmake_unit_get_target_location_from_exports EXPORTS
+                                                      BINARY_DIR
                                                       TARGET
                                                       LOCATION_RETURN)
 
@@ -531,7 +532,7 @@ function (cmake_unit_get_target_location_from_exports EXPORTS
     # cannot do so whilst in script mode) and then prints the location
     # on the stderr. We'll capture this and return it.
     set (DETERMINE_LOCATION_DIRECTORY
-         "${CMAKE_CURRENT_BINARY_DIR}/determine_location_for_${TARGET}")
+         "${BINARY_DIR}/dle_${TARGET}")
     set (DETERMINE_LOCATION_BINARY_DIRECTORY
          "${DETERMINE_LOCATION_DIRECTORY}/build")
     set (DETERMINE_LOCATION_CAPTURE
@@ -539,9 +540,9 @@ function (cmake_unit_get_target_location_from_exports EXPORTS
     set (DETERMINE_LOCATION_CMAKELISTS_TXT_FILE
          "${DETERMINE_LOCATION_DIRECTORY}/CMakeLists.txt")
     set (DETERMINE_LOCATION_CMAKELISTS_TXT
-         "include (${EXPORTS})\n"
+         "include (\"${EXPORTS}\")\n"
          "get_property (LOCATION TARGET ${TARGET} PROPERTY LOCATION)\n"
-         "file (WRITE ${DETERMINE_LOCATION_CAPTURE} \"\${LOCATION}\")\n")
+         "file (WRITE \"${DETERMINE_LOCATION_CAPTURE}\" \"\${LOCATION}\")\n")
 
     string (REPLACE ";" ""
             DETERMINE_LOCATION_CMAKELISTS_TXT
@@ -587,16 +588,16 @@ endfunction ()
 function (cmake_unit_export_cfg_int_dir LOCATION)
 
     get_filename_component (LOCATION_NAME "${LOCATION}" NAME)
-    set (WRITE_TO_OUTPUT_FILE_SCRIPT ${LOCATION}.write.cmake)
+    set (WRITE_TO_OUTPUT_SCRIPT_FILE "${LOCATION}.write.cmake")
     set (WRITE_TO_OUTPUT_FILE_SCRIPT_CONTENTS
-         "file (WRITE ${LOCATION} \"\${INTDIR}\")\n")
-    file (WRITE ${WRITE_TO_OUTPUT_FILE_SCRIPT}
+         "file (WRITE \"${LOCATION}\" \"\${INTDIR}\")\n")
+    file (WRITE "${WRITE_TO_OUTPUT_SCRIPT_FILE}"
           "${WRITE_TO_OUTPUT_FILE_SCRIPT_CONTENTS}")
     add_custom_command (OUTPUT ${LOCATION}
                         COMMAND "${CMAKE_COMMAND}"
                                 -DINTDIR=${CMAKE_CFG_INTDIR}
                                 -P
-                                ${WRITE_TO_OUTPUT_FILE_SCRIPT})
+                                "${WRITE_TO_OUTPUT_SCRIPT_FILE}")
     add_custom_target (write_cfg_int_dir_${LOCATION_NAME} ALL
                        SOURCES ${LOCATION})
 

--- a/CMakeUnitRunner.cmake
+++ b/CMakeUnitRunner.cmake
@@ -402,8 +402,8 @@ function (_cmake_unit_preconfigure_test)
     # into CMAKE_UNIT_COVERAGE_FILE
     _cmake_unit_spacify (POLICY_CACHE_DEFS_SPACIFIED
                          LIST ${CMAKE_POLICY_CACHE_DEFINITIONS})
-    set (DRIVER_OUTPUT_LOG "${CMAKE_CURRENT_BINARY_DIR}/DRIVER.output")
-    set (DRIVER_ERROR_LOG "${CMAKE_CURRENT_BINARY_DIR}/DRIVER.error")
+    set (DRIVER_OUTPUT_LOG "${PRECONFIGURE_TEST_BINARY_DIR}/DRIVER.output")
+    set (DRIVER_ERROR_LOG "${PRECONFIGURE_TEST_BINARY_DIR}/DRIVER.error")
 
     set (TRACE_OPTION)
     if (CMAKE_UNIT_COVERAGE_FILE AND
@@ -425,7 +425,7 @@ function (_cmake_unit_preconfigure_test)
           "include (\"${_RUNNER_LIST_FILE}\")\n"
           "_cmake_unit_invoke_command (COMMAND \"${CMAKE_COMMAND}\"\n"
           "                                    ${POLICY_CACHE_DEFS_SPACIFIED}\n"
-          "                                    -P ${DRIVER_SCRIPT}\n"
+          "                                    -P \"${DRIVER_SCRIPT}\"\n"
           "                                    ${TRACE_OPTION}\n"
           "                            OUTPUT_FILE \"${DRIVER_OUTPUT_LOG}\"\n"
           "                            ERROR_FILE \"${DRIVER_ERROR_LOG}\"\n"
@@ -508,7 +508,7 @@ function (_cmake_unit_print_lines_for_log PHASE
     # same format for each
     if (LOG_TYPE STREQUAL "ERROR")
 
-        set (MESSAGE_INITIAL_ARGS " -- ")
+        set (MESSAGE_INITIAL_ARGS "-- ")
 
     elseif (LOG_TYPE STREQUAL "OUTPUT")
 
@@ -858,8 +858,7 @@ function (_cmake_unit_coverage)
 
         if (EXISTS "${ERROR_LOG_FILE}")
 
-            file (STRINGS "${ERROR_LOG_FILE}"
-                  INVOKE_CONFIGURE_ERROR)
+            file (STRINGS "${ERROR_LOG_FILE}" ERROR_LOG)
 
             get_property (COVERAGE_FILES
                           GLOBAL PROPERTY _CMAKE_UNIT_COVERAGE_LOGGING_FILES)
@@ -868,10 +867,14 @@ function (_cmake_unit_coverage)
                                             TEST_NAME
                                             "${COVERAGE_PHASE_TEST_NAME}"
                                             TRACE_LINES
-                                            "${INVOKE_CONFIGURE_ERROR}"
+                                            "${ERROR_LOG}"
                                             COVERAGE_FILES ${COVERAGE_FILES})
 
-            file (APPEND "${CMAKE_UNIT_COVERAGE_FILE}"
+            get_filename_component (ABSOLUTE_COVERAGE_FILE_PATH
+                                    "${CMAKE_UNIT_COVERAGE_FILE}"
+                                    ABSOLUTE)
+
+            file (APPEND "${ABSOLUTE_COVERAGE_FILE_PATH}"
                   ${COVERAGE_FILE_CONTENTS})
 
         endif ()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -153,7 +153,14 @@ function (_cmake_unit_test_gen_discover_from_contents)
          ${GEN_DISCOVER_CONTENTS})
 
     set (INIT_OPTIONS "${GEN_DISCOVER_INIT_OPTIONS}")
-    string (REPLACE ";" " " INIT_OPTIONS "${INIT_OPTIONS}")
+
+    # Ensure everything in INIT_OPTIONS is quoted so that
+    # there is no ambiguity when we insert it into the
+    # AuxCMakeLists.txt script later.
+    foreach (OPTION ${INIT_OPTIONS})
+        list (APPEND QUOTED_INIT_OPTIONS "\"${OPTION}\"")
+    endforeach ()
+    string (REPLACE ";" " " INIT_OPTIONS "${QUOTED_INIT_OPTIONS}")
 
     list (APPEND AUX_CMAKELISTS_FILE_CONTENTS
           "set (NEXT_TESTS)\n"
@@ -311,7 +318,7 @@ function (cmake_unit_test_cmake_build_test_error_on_build_fail)
         set (SOURCE "${SOURCE_DIR}/Source.cpp")
         file (WRITE "${SOURCE}" "invalid(")
 
-        set (CONFIGURE_SCRIPT "add_executable (exec ${SOURCE})\n")
+        set (CONFIGURE_SCRIPT "add_executable (exec \"${SOURCE}\")\n")
         _cmake_unit_test_gen_configure (NAMESPACE sample
                                         NAME one
                                         INVOKE_CONFIGURE OPTIONS
@@ -703,13 +710,7 @@ function (cmake_unit_test_cmake_test_files_recorded_in_tracefile_across_tests)
 
     cmake_unit_get_dirs (BINARY_DIR SOURCE_DIR)
 
-    set (COVERAGE_TRACEFILE "${BINARY_DIR}/coverage.trace")
-
     function (_cmake_unit_configure)
-
-        set (CMAKE_UNIT_LOG_COVERAGE ON CACHE BOOL "" FORCE)
-        set (CMAKE_UNIT_COVERAGE_FILE "${COVERAGE_TRACEFILE}"
-             CACHE STRING "" FORCE)
 
         set (EXCLUDED "${CMAKE_CURRENT_BINARY_DIR}/Excluded.cmake")
         set (INCLUDED "${CMAKE_CURRENT_BINARY_DIR}/Included.cmake")
@@ -728,9 +729,9 @@ function (cmake_unit_test_cmake_test_files_recorded_in_tracefile_across_tests)
               "message (STATUS \"Second Test Specific Script\")\n")
 
         set (TEST_ONE
-             "include (${EXCLUDED})\n"
-             "include (${INCLUDED})\n"
-             "include (${FIRST_TEST_SPECIFIC})\n")
+             "include (\"${EXCLUDED}\")\n"
+             "include (\"${INCLUDED}\")\n"
+             "include (\"${FIRST_TEST_SPECIFIC}\")\n")
 
         _cmake_unit_test_gen_configure_no_discover (TEST_ONE_CONTENTS
                                                     NAMESPACE sample
@@ -745,9 +746,9 @@ function (cmake_unit_test_cmake_test_files_recorded_in_tracefile_across_tests)
                                                               "${TEST_ONE}")
 
         set (TEST_TWO
-             "include (${EXCLUDED})\n"
-             "include (${INCLUDED})\n"
-             "include (${SECOND_TEST_SPECIFIC})\n")
+             "include (\"${EXCLUDED}\")\n"
+             "include (\"${INCLUDED}\")\n"
+             "include (\"${SECOND_TEST_SPECIFIC}\")\n")
 
         _cmake_unit_test_gen_configure_no_discover (TEST_TWO_CONTENTS
                                                     NAMESPACE sample
@@ -765,6 +766,8 @@ function (cmake_unit_test_cmake_test_files_recorded_in_tracefile_across_tests)
         set (END "end")
 
         set (CONTENTS_PROLOGUE
+             "set (CMAKE_UNIT_COVERAGE_FILE \"coverage.trace\"\n"
+             "     CACHE STRING \"\" FORCE)\n"
              "if (NOT CMAKE_SCRIPT_MODE_FILE)\n"
              "    project (SampleTests NONE)\n"
              "${END}if ()\n")
@@ -782,6 +785,8 @@ function (cmake_unit_test_cmake_test_files_recorded_in_tracefile_across_tests)
     endfunction ()
 
     function (_cmake_unit_verify)
+
+        set (COVERAGE_TRACEFILE "${BINARY_DIR}/coverage.trace")
 
         cmake_unit_assert_file_exists ("${COVERAGE_TRACEFILE}")
 
@@ -973,6 +978,7 @@ function (cmake_unit_test_create_simple_executable)
 
         set (EXPORTS_FILE "${BINARY_DIR}/exports.cmake")
         cmake_unit_get_target_location_from_exports ("${EXPORTS_FILE}"
+                                                     "${BINARY_DIR}"
                                                      executable
                                                      LOCATION)
 
@@ -1052,13 +1058,13 @@ function (cmake_unit_test_export_import_cfg_int_dir)
                 "${CMAKE_MODULE_PATH}")
         set (EXTERNAL_PROJECT_CMAKELISTS_TXT_CONTENT
              "cmake_minimum_required (VERSION 2.8)\n"
-             "set (CMAKE_MODULE_PATH ${STRINGIFIED_CMAKE_MODULE_PATH})\n"
+             "set (CMAKE_MODULE_PATH \"${STRINGIFIED_CMAKE_MODULE_PATH}\")\n"
              "include (CMakeUnit)\n"
              "cmake_unit_create_simple_executable (executable)\n"
              "export (TARGETS executable\n"
-             "        FILE ${EXTERNAL_PROJECT_EXPORTS})\n"
-             "set (CFG_INT_DIR_LOCATION ${BINARY_DIR}/CfgIntDir.txt)\n"
-             "cmake_unit_export_cfg_int_dir (\${CFG_INT_DIR_LOCATION})\n")
+             "        FILE \"${EXTERNAL_PROJECT_EXPORTS}\")\n"
+             "set (CFG_INT_DIR_LOCATION \"${BINARY_DIR}/CfgIntDir.txt\")\n"
+             "cmake_unit_export_cfg_int_dir (\"\${CFG_INT_DIR_LOCATION}\")\n")
 
         file (MAKE_DIRECTORY "${EXTERNAL_PROJECT_SOURCE_DIR}")
         file (MAKE_DIRECTORY "${EXTERNAL_PROJECT_BINARY_DIR}")
@@ -1079,6 +1085,7 @@ function (cmake_unit_test_export_import_cfg_int_dir)
         cmake_unit_import_cfg_int_dir ("${BINARY_DIR}/CfgIntDir.txt"
                                        CFG_INT_DIR)
         cmake_unit_get_target_location_from_exports ("${EXTERNAL_PROJECT_EXPORTS}"
+                                                     "${BINARY_DIR}"
                                                      executable
                                                      EXECUTABLE_LOCATION)
 


### PR DESCRIPTION
This fixes the coverage mode on Windows.