### PR TITLE
Add CMAKE_UNIT_INVOKING_BINARY_DIR variable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -823,6 +823,34 @@ function (cmake_unit_test_cmake_build_test_no_errors_where_w_error_disabled)
 
 endfunction ()
 
+# Check that we can read files put into the top-level binary directory, above
+# the tests. This is useful in cases where we might want to generate an
+# executable once during the build phase and re-use it during the tests.
+function (cmake_unit_test_can_read_from_invoking_binary_dir)
+
+    function (_cmake_unit_configure)
+
+        set (GENERATED_FILE "Generated.cpp")
+        cmake_unit_generate_source_file_during_build (TARGET
+                                                      NAME "${GENERATED_FILE}"
+                                                      GENERATED_FILE
+                                                      "${_CURRENT_LIST_FILE}")
+        set (VERIFY_SCRIPT
+             "cmake_unit_assert_that ("
+             "\"\${CMAKE_UNIT_INVOKING_BINARY_DIR}/${GENERATED_FILE}\""
+             "exists_as_file)\n")
+
+        _cmake_unit_test_gen_configure (NAMESPACE sample
+                                        NAME one
+                                        VERIFY SCRIPT "${VERIFY_SCRIPT}")
+
+    endfunction ()
+
+    cmake_unit_configure_test (CONFIGURE COMMAND _cmake_unit_configure
+                               INVOKE_CONFIGURE OPTIONS LANGUAGES C CXX)
+
+endfunction ()
+
 # Set up some tests which will include some specified scripts, but not
 # a certain excluded script. Eg
 # First Test:

--- a/CMakeUnitRunner.cmake
+++ b/CMakeUnitRunner.cmake
@@ -348,6 +348,8 @@ function (_cmake_unit_preconfigure_test)
          "     CACHE BOOL \"\" FORCE)\n"
          "set (CMAKE_PROJECT_NAME\n"
          "     \"${CMAKE_PROJECT_NAME}\")\n"
+         "set (CMAKE_UNIT_INVOKING_BINARY_DIR\n"
+         "     \"${CMAKE_CURRENT_BINARY_DIR}\")\n"
          "set_property (GLOBAL PROPERTY\n"
          "              _CMAKE_UNIT_COVERAGE_LOGGING_FILES\n"
          "              ${COVERAGE_FILES})\n"


### PR DESCRIPTION
This variable, available during the tests, specifies the binary
directory during the time cmake was invoked in the toplevel
CMakeLists.txt file, i.e, during the PRECONFIGURE phase. It is
useful if the preconfigure phase may generate a file that is
used repeatedly across tests.