### PR TITLE
Make failure to have an extension a fatal error.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1161,6 +1161,34 @@ function (cmake_unit_test_source_file_generated_during_build_exists)
 
 endfunction ()
 
+# Exit with a fatal error if the source file passed to
+# cmake_unit_create_source_file_before_build does not have a valid
+# extension.
+function (cmake_unit_test_source_file_created_before_build_needs_extension)
+
+    cmake_unit_get_dirs (BINARY_DIR SOURCE_DIR)
+
+    function (_cmake_unit_configure)
+
+        cmake_unit_create_source_file_before_build (NAME "incorrect")
+
+    endfunction ()
+
+    function (_cmake_unit_verify)
+
+        cmake_unit_get_log_for (INVOKE_CONFIGURE ERROR CONFIGURE_ERROR)
+        cmake_unit_assert_that ("${CONFIGURE_ERROR}"
+                                file_contents any_line matches_regex
+                                "^.*current name is incorrect.*$")
+
+    endfunction ()
+
+    cmake_unit_configure_test (CONFIGURE COMMAND _cmake_unit_configure
+                               VERIFY COMMAND _cmake_unit_verify
+                               INVOKE_CONFIGURE OPTIONS ALLOW_FAIL)
+
+endfunction ()
+
 # Check that source files created and generated with the same options
 # are completely equal. The hash of both should be equal.
 function (cmake_unit_test_generated_and_created_source_files_equal)

--- a/CMakeUnit.cmake
+++ b/CMakeUnit.cmake
@@ -286,15 +286,18 @@ function (_cmake_unit_get_created_source_file_contents CONTENTS_RETURN
     endif ()
 
     # Detect intended file type from filename
+
     get_filename_component (EXTENSION "${GET_CREATED_NAME}" EXT)
 
-    # Remove leading dot
-    if (EXTENSION)
+    if (NOT EXTENSION)
 
-        string (SUBSTRING "${EXTENSION}" 1 -1 EXTENSION)
+        message (FATAL_ERROR "Need to specify an extension in order to get "
+                             "correct source file contents for this file. The "
+                             "current name is ${GET_CREATED_NAME}.")
 
     endif ()
 
+    string (SUBSTRING "${EXTENSION}" 1 -1 EXTENSION)
     set (SOURCE_EXTENSIONS
          ${CMAKE_C_SOURCE_FILE_EXTENSIONS}
          ${CMAKE_CXX_SOURCE_FILE_EXTENSIONS})


### PR DESCRIPTION
The last commit allowed for files to not have an extesnion. In
reality, this made no sense - the extension is required in order
to determine the contents of the file. Make not having an extension
a clear error.