### PR TITLE
CMakeUnitRunner: Add FORWARD_CACHE_VARIABLES option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -937,6 +937,33 @@ function (cmake_unit_test_forward_output_directories)
 
 endfunction ()
 
+# Check that output directories are forwarded.
+function (cmake_unit_test_custom_cache_variables)
+
+    set (CACHE_VARIABLE_VALUE "value")
+
+    function (_cmake_unit_configure)
+
+        set (CACHE_VARIABLE "${CACHE_VARIABLE_VALUE}")
+
+        set (CONFIGURE_SCRIPT
+             "cmake_unit_assert_that ("
+             "CACHE_VARIABLE compare_as "
+             "STRING EQUAL \"${CACHE_VARIABLE_VALUE}\")\n")
+
+        _cmake_unit_test_gen_configure (NAMESPACE sample
+                                        NAME one
+                                        CONFIGURE SCRIPT "${CONFIGURE_SCRIPT}"
+                                        PRECONFIGURE OPTIONS
+                                                     FORWARD_CACHE_VARIABLES
+                                                     CACHE_VARIABLE)
+
+    endfunction ()
+
+    cmake_unit_configure_test (CONFIGURE COMMAND _cmake_unit_configure)
+
+endfunction ()
+
 # Set up some tests which will include some specified scripts, but not
 # a certain excluded script. Eg
 # First Test:

--- a/biicode.conf
+++ b/biicode.conf
@@ -1,11 +1,12 @@
 # Biicode configuration file
 
 [requirements]
-    smspillaz/cmake-include-guard: 0
-    smspillaz/cmake-call-function: 0
-    smspillaz/cmake-forward-arguments: 0
-    smspillaz/cmake-opt-arg-parsing: 0
-    smspillaz/cmake-spacify-list: 0
+	 smspillaz/cmake-call-function: 0
+	 smspillaz/cmake-forward-arguments: 0
+	 smspillaz/cmake-forward-cache: 0
+	 smspillaz/cmake-include-guard: 0
+	 smspillaz/cmake-opt-arg-parsing: 0
+	 smspillaz/cmake-spacify-list: 0
 
 [parent]
     smspillaz/cmake-unit: 0


### PR DESCRIPTION
This option allows the test author to forward certain variables
and make them part of the test's cache from the PRECONFIGURE
phase, which is useful if there is a step to be run
during preconfigure which should not be run again during
the tests.